### PR TITLE
Fix activity allocated cost

### DIFF
--- a/ui/allocation_page.py
+++ b/ui/allocation_page.py
@@ -254,6 +254,7 @@ class AllocationPage(NSObject):
             """, (r_id, a_id, amt))
         con.commit()
         con.close()
+        database.update_activity_costs()
         self.refresh()
 
     def deleteResAlloc_(self, sender):
@@ -275,6 +276,7 @@ class AllocationPage(NSObject):
                 "DELETE FROM resource_allocations_monthly WHERE resource_id=? AND activity_id=?", (r_id, a_id))
             con.commit()
         con.close()
+        database.update_activity_costs()
         self.refresh()
 
     # ------------- Show remaining cost on resource selection ------------- #

--- a/ui/resources_page.py
+++ b/ui/resources_page.py
@@ -131,6 +131,7 @@ class ResourcesPage(NSObject):
                 "INSERT INTO resource_costs(resource_id, period, cost) SELECT ?, period, ? FROM periods", (rid, cost))
         con.commit()
         con.close()
+        database.update_activity_costs()
         self.refresh()
         self.clear_form()
 
@@ -157,6 +158,7 @@ class ResourcesPage(NSObject):
             cur.execute("DELETE FROM resources WHERE id=?", (rid,))
             con.commit()
             con.close()
+            database.update_activity_costs()
             self.refresh()
             self.clear_form()
 


### PR DESCRIPTION
## Summary
- add `allocated_cost` column to activities
- compute allocated cost whenever resources or allocations change
- update UI pages to trigger recalculation

## Testing
- `python -m py_compile *.py ui/*.py`
- `python - <<'PY'
import database

database.init_db()
database.reset_all_tables()
database.insert_data()

con = database.get_connection()
cur = con.cursor()
cur.execute('SELECT id,allocated_cost FROM activities')
print(cur.fetchall())
con.close()
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6876183b6080832ab949676298dd91f7