### PR TITLE
Add Excel import/export and menu integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+model.xlsx


### PR DESCRIPTION
## Summary
- load initial data via `insert_data()` from `model.xlsx` when present
- integrate Import/Export options in the app menu bar
- add Excel import/export helpers in `database.py`
- ignore local `model.xlsx`

## Testing
- `python -m py_compile database.py ui/main_window.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68762ffcfc48832aaf63ba81060c5014