### PR TITLE
Fix cost object allocation and graph drawing

### DIFF
--- a/ui/allocation_page.py
+++ b/ui/allocation_page.py
@@ -371,6 +371,7 @@ class AllocationPage(NSObject):
             """, (a_id, c_id, qty, driver_val_id))
         con.commit()
         con.close()
+        database.update_cost_object_costs()
         self.refresh()
 
     def deleteActAlloc_(self, sender):
@@ -391,6 +392,7 @@ class AllocationPage(NSObject):
                 "DELETE FROM activity_allocations_monthly WHERE activity_id=? AND cost_object_id=?", (a_id, c_id))
             con.commit()
         con.close()
+        database.update_cost_object_costs()
         self.refresh()
 
     # ---------------- Refresh UI/Data ---------------- #

--- a/ui/cost_objects_page.py
+++ b/ui/cost_objects_page.py
@@ -14,7 +14,7 @@ class CostObjectsPage(NSObject):
         self.view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
         table_rect = NSMakeRect(0, 30, 1000, 590)
         self.tree = NSTableView.alloc().initWithFrame_(table_rect)
-        columns = [("id", 150), ("name", 200)]
+        columns = [("id", 150), ("name", 200), ("allocated_cost", 150)]
         for col_id, width in columns:
             col = NSTableColumn.alloc().initWithIdentifier_(col_id)
             col.setWidth_(width)
@@ -60,6 +60,8 @@ class CostObjectsPage(NSObject):
             return str(self.rows[rowIndex][0])
         elif col_id == "name":
             return self.rows[rowIndex][1]
+        elif col_id == "allocated_cost":
+            return str(self.rows[rowIndex][2])
         return ""
 
     def tableViewSelectionDidChange_(self, notification):
@@ -119,7 +121,7 @@ class CostObjectsPage(NSObject):
     def refresh(self):
         con = database.get_connection()
         cur = con.cursor()
-        cur.execute("SELECT id, name FROM cost_objects")
+        cur.execute("SELECT id, name, allocated_cost FROM cost_objects")
         self.rows = cur.fetchall()
         con.close()
         self.tree.reloadData()


### PR DESCRIPTION
## Summary
- simplify database schema without migrations
- compute cost object allocated cost from activities
- expose allocated cost on cost object page
- update allocation logic to recalc cost objects
- redraw graph without networkx dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876453efa80832abaf5de4b21a66a53