### PR TITLE
Remove monthly allocation logic

### DIFF
--- a/calculation.py
+++ b/calculation.py
@@ -18,8 +18,8 @@ def calculate_costs(conn, period=None):
             "ON r.id = rc.resource_id AND rc.period=?", (period_code,))
         resources = {row[0]: row[1] for row in cur.fetchall()}
         cur.execute(
-            "SELECT resource_id, activity_id, amount FROM resource_allocations_monthly "
-            "WHERE period=?", (period_code,))
+            "SELECT resource_id, activity_id, amount FROM resource_allocations"
+        )
         res_alloc = {}
         total_by_resource = {}
         for r_id, a_id, amount in cur.fetchall():
@@ -38,8 +38,8 @@ def calculate_costs(conn, period=None):
 
         # Step 2 – calculate cost object totals for the period
         cur.execute(
-            "SELECT activity_id, cost_object_id, driver_amt FROM activity_allocations_monthly WHERE period=?",
-            (period_code,))
+            "SELECT activity_id, cost_object_id, driver_amt FROM activity_allocations"
+        )
         act_alloc = {}
         total_by_activity = {}
         for a_id, c_id, amt in cur.fetchall():

--- a/migrations/drop_monthly_tables.sql
+++ b/migrations/drop_monthly_tables.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS resource_allocations_monthly;
+DROP TABLE IF EXISTS activity_allocations_monthly;

--- a/ui/graph_page.py
+++ b/ui/graph_page.py
@@ -50,7 +50,8 @@ class GraphPage(NSObject):
                          for row in cur.fetchall()}
         # Resource->Activity allocations
         cur.execute(
-            "SELECT resource_id, activity_id, amount FROM resource_allocations_monthly WHERE period=?", (period,))
+            "SELECT resource_id, activity_id, amount FROM resource_allocations"
+        )
         res_alloc = {}
         total_by_res = {}
         for r_id, a_id, amount in cur.fetchall():
@@ -69,7 +70,9 @@ class GraphPage(NSObject):
                     a_id, 0) + cost_contrib
                 resource_to_activity[(r_id, a_id)] = cost_contrib
         # Activity->CostObject allocations
-        cur.execute("SELECT activity_id, cost_object_id, driver_amt FROM activity_allocations_monthly WHERE period=?", (period,))
+        cur.execute(
+            "SELECT activity_id, cost_object_id, driver_amt FROM activity_allocations"
+        )
         act_alloc = {}
         total_by_act = {}
         for a_id, c_id, amt in cur.fetchall():


### PR DESCRIPTION
## Summary
- drop `resource_allocations_monthly` and `activity_allocations_monthly` tables
- remove all monthly allocation handling from the database layer
- update calculation logic and UI pages to use regular allocation tables
- add migration script to remove the old monthly tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a1f446b4832a97d0b85aac853bc6