### PR TITLE
Redesign activity and cost object structure

### DIFF
--- a/database.py
+++ b/database.py
@@ -29,7 +29,8 @@ def init_db():
 
     CREATE TABLE IF NOT EXISTS activities (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
-        name TEXT NOT NULL,
+        business_procces TEXT NOT NULL,
+        activity TEXT NOT NULL,
         driver_id INTEGER REFERENCES drivers(id) ON DELETE RESTRICT,
         evenly INTEGER NOT NULL DEFAULT 0,
         allocated_cost REAL NOT NULL DEFAULT 0
@@ -37,7 +38,8 @@ def init_db():
 
     CREATE TABLE IF NOT EXISTS cost_objects (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
-        name TEXT NOT NULL,
+        product TEXT NOT NULL,
+        business_procces TEXT NOT NULL,
         allocated_cost REAL NOT NULL DEFAULT 0
     );
 
@@ -70,10 +72,10 @@ def init_db():
     CREATE TABLE IF NOT EXISTS driver_values (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         driver_id INTEGER NOT NULL,
-        cost_object_nm TEXT NOT NULL,
+        product TEXT NOT NULL,
         value REAL NOT NULL,
         FOREIGN KEY (driver_id) REFERENCES drivers(id) ON DELETE CASCADE,
-        UNIQUE(driver_id, cost_object_nm)
+        UNIQUE(driver_id, product)
     );
 
     CREATE TABLE IF NOT EXISTS periods (
@@ -245,25 +247,31 @@ def apply_driver_values(dv_ids: list[int] | None = None) -> None:
     if dv_ids:
         placeholders = ",".join("?" for _ in dv_ids)
         cur.execute(
-            f"SELECT id, driver_id, cost_object_nm, value FROM driver_values WHERE id IN ({placeholders})",
+            f"SELECT id, driver_id, product, value FROM driver_values WHERE id IN ({placeholders})",
             dv_ids,
         )
     else:
         cur.execute(
-            "SELECT id, driver_id, cost_object_nm, value FROM driver_values")
+            "SELECT id, driver_id, product, value FROM driver_values")
 
-    for dv_id, driver_id, co_name, val in cur.fetchall():
-        cur.execute("SELECT id FROM cost_objects WHERE name=?", (co_name,))
-        row = cur.fetchone()
-        if row:
-            co_id = row[0]
-        else:
-            cur.execute("INSERT INTO cost_objects(name) VALUES(?)", (co_name,))
-            co_id = cur.lastrowid
+    for dv_id, driver_id, product, val in cur.fetchall():
+        cur.execute("SELECT id, business_procces FROM activities WHERE driver_id=?", (driver_id,))
+        act_rows = cur.fetchall()
+        for a_id, bproc in act_rows:
+            cur.execute(
+                "SELECT id FROM cost_objects WHERE product=? AND business_procces=?",
+                (product, bproc),
+            )
+            row = cur.fetchone()
+            if row:
+                co_id = row[0]
+            else:
+                cur.execute(
+                    "INSERT INTO cost_objects(product, business_procces) VALUES(?, ?)",
+                    (product, bproc),
+                )
+                co_id = cur.lastrowid
 
-        cur.execute("SELECT id FROM activities WHERE driver_id=?", (driver_id,))
-        act_ids = [r[0] for r in cur.fetchall()]
-        for a_id in act_ids:
             cur.execute(
                 "INSERT OR IGNORE INTO activity_allocations(activity_id, cost_object_id, driver_amt, driver_value_id, allocated_cost)"
                 " VALUES(?,?,?,?,0)",
@@ -335,40 +343,41 @@ def export_to_excel(file_path: str):
     df_resources = pd.DataFrame(
         res, columns=["id", "name", "cost_total", "unit"])
     # Activities (with driver name instead of id for clarity)
-    cur.execute("""SELECT a.id, a.name,
-                          IFNULL(d.name, '') AS driver, 
+    cur.execute("""SELECT a.id, a.business_procces, a.activity,
+                          IFNULL(d.name, '') AS driver,
                           a.evenly
                    FROM activities a
                    LEFT JOIN drivers d ON a.driver_id = d.id""")
     acts = cur.fetchall()
     df_activities = pd.DataFrame(
-        acts, columns=["id", "name", "driver", "evenly"])
+        acts, columns=["id", "business_procces", "activity", "driver", "evenly"])
     # Cost Objects
-    cur.execute("SELECT id, name, allocated_cost FROM cost_objects")
+    cur.execute("SELECT id, product, business_procces, allocated_cost FROM cost_objects")
     cos = cur.fetchall()
-    df_costobj = pd.DataFrame(cos, columns=["id", "name", "allocated_cost"])
+    df_costobj = pd.DataFrame(cos, columns=["id", "product", "business_procces", "allocated_cost"])
     # Drivers
     cur.execute("SELECT id, name FROM drivers")
     dr = cur.fetchall()
     df_drivers = pd.DataFrame(dr, columns=["id", "name"])
     # Driver Values (with driver name)
-    cur.execute("""SELECT dv.id, d.name AS driver, dv.cost_object_nm, dv.value
+    cur.execute("""SELECT dv.id, d.name AS driver, dv.product, dv.value
                    FROM driver_values dv
                    JOIN drivers d ON dv.driver_id = d.id""")
     dvs = cur.fetchall()
     df_driver_vals = pd.DataFrame(
-        dvs, columns=["id", "driver", "cost_object_nm", "value"])
+        dvs, columns=["id", "driver", "product", "value"])
     # Resource Allocations (with resource and activity names)
-    cur.execute("""SELECT r.id, r.name, a.id, a.name, ra.amount
+    cur.execute("""SELECT r.id, r.name, a.id, a.business_procces, a.activity, ra.amount
                    FROM resource_allocations ra
                    JOIN resources r ON ra.resource_id = r.id
                    JOIN activities a ON ra.activity_id = a.id""")
     ra = cur.fetchall()
     df_res_alloc = pd.DataFrame(ra, columns=[
-                                "resource_id", "resource_name", "activity_id", "activity_name", "amount"])
+                                "resource_id", "resource_name", "activity_id", "business_procces", "activity", "amount"])
     # Activity Allocations (with activity and cost_object names, and driver value name)
-    cur.execute("""SELECT a.id, a.name, c.id, c.name,
-                          IFNULL(dv.cost_object_nm, '') AS driver_value,
+    cur.execute("""SELECT a.id, a.business_procces, a.activity,
+                          c.id, c.product, c.business_procces,
+                          IFNULL(dv.product, '') AS driver_value,
                           aa.driver_amt, aa.allocated_cost
                    FROM activity_allocations aa
                    JOIN activities a ON aa.activity_id = a.id
@@ -376,7 +385,9 @@ def export_to_excel(file_path: str):
                    LEFT JOIN driver_values dv ON aa.driver_value_id = dv.id""")
     aa = cur.fetchall()
     df_act_alloc = pd.DataFrame(aa, columns=[
-                                "activity_id", "activity_name", "cost_object_id", "cost_object_name", "driver_value", "driver_amt", "allocated_cost"])
+                                "activity_id", "business_procces", "activity",
+                                "cost_object_id", "product", "cost_object_bp",
+                                "driver_value", "driver_amt", "allocated_cost"])
     con.close()
     # Write dataframes to an Excel file
     with pd.ExcelWriter(file_path, engine='openpyxl') as writer:
@@ -472,10 +483,11 @@ def import_from_excel(file_path: str):
                         (name, cost_total, unit))
 
     # Import Activities
-    activity_map = {}  # map activity name to id
+    activity_map = {}  # map (business_procces, activity) to id
     for _, row in df_activities.iterrows():
-        name = str(row["name"]).strip()
-        if not name:
+        bproc = str(row["business_procces"]).strip()
+        act_name = str(row["activity"]).strip()
+        if not bproc or not act_name:
             continue
         # Determine driver_id from driver name, and evenly flag
         driver_name = str(row.get("driver", "")).strip()
@@ -492,43 +504,47 @@ def import_from_excel(file_path: str):
         if pd.notna(row.get("id")):
             a_id = int(row["id"])
             cur.execute(
-                "INSERT OR IGNORE INTO activities(id, name, driver_id, evenly) VALUES(?, ?, ?, ?)",
-                (a_id, name, driver_id, evenly_flag)
+                "INSERT OR IGNORE INTO activities(id, business_procces, activity, driver_id, evenly) VALUES(?, ?, ?, ?, ?)",
+                (a_id, bproc, act_name, driver_id, evenly_flag)
             )
             cur.execute(
-                "UPDATE activities SET name=?, driver_id=?, evenly=? WHERE id=?",
-                (name, driver_id, evenly_flag, a_id)
+                "UPDATE activities SET business_procces=?, activity=?, driver_id=?, evenly=? WHERE id=?",
+                (bproc, act_name, driver_id, evenly_flag, a_id)
             )
         else:
-            cur.execute("INSERT INTO activities(name, driver_id, evenly) VALUES(?, ?, ?)",
-                        (name, driver_id, evenly_flag))
+            cur.execute(
+                "INSERT INTO activities(business_procces, activity, driver_id, evenly) VALUES(?, ?, ?, ?)",
+                (bproc, act_name, driver_id, evenly_flag))
             a_id = cur.lastrowid
-        activity_map[name] = a_id
+        activity_map[(bproc, act_name)] = a_id
 
     # Import Cost Objects
     costobj_map = {}
     for _, row in df_costobj.iterrows():
-        name = str(row["name"]).strip()
-        if not name:
+        product = str(row["product"]).strip()
+        bproc = str(row["business_procces"]).strip()
+        if not product or not bproc:
             continue
         if pd.notna(row.get("id")):
             c_id = int(row["id"])
             cur.execute(
-                "INSERT OR IGNORE INTO cost_objects(id, name) VALUES(?, ?)",
-                (c_id, name)
+                "INSERT OR IGNORE INTO cost_objects(id, product, business_procces) VALUES(?, ?, ?)",
+                (c_id, product, bproc)
             )
             cur.execute(
-                "UPDATE cost_objects SET name=? WHERE id=?", (name, c_id))
+                "UPDATE cost_objects SET product=?, business_procces=? WHERE id=?",
+                (product, bproc, c_id))
         else:
-            cur.execute("INSERT INTO cost_objects(name) VALUES(?)", (name,))
+            cur.execute("INSERT INTO cost_objects(product, business_procces) VALUES(?, ?)",
+                        (product, bproc))
             c_id = cur.lastrowid
-        costobj_map[name] = c_id
+        costobj_map[(product, bproc)] = c_id
 
     # Import Driver Values
     for _, row in df_driver_vals.iterrows():
         driver_name = str(row["driver"]).strip()
-        co_name = str(row["cost_object_nm"]).strip()
-        if not driver_name or not co_name:
+        product = str(row["product"]).strip()
+        if not driver_name or not product:
             continue
         value = float(row["value"]) if pd.notna(row["value"]) else 0.0
         # Ensure driver exists (in case it was not in Drivers sheet but appears here)
@@ -540,28 +556,27 @@ def import_from_excel(file_path: str):
         if pd.notna(row.get("id")):
             dv_id = int(row["id"])
             cur.execute(
-                "INSERT OR IGNORE INTO driver_values(id, driver_id, cost_object_nm, value) VALUES(?, ?, ?, ?)",
-                (dv_id, d_id, co_name, value)
+                "INSERT OR IGNORE INTO driver_values(id, driver_id, product, value) VALUES(?, ?, ?, ?)",
+                (dv_id, d_id, product, value)
             )
             cur.execute(
-                "UPDATE driver_values SET driver_id=?, cost_object_nm=?, value=? WHERE id=?",
-                (d_id, co_name, value, dv_id)
+                "UPDATE driver_values SET driver_id=?, product=?, value=? WHERE id=?",
+                (d_id, product, value, dv_id)
             )
         else:
             cur.execute(
-                "INSERT INTO driver_values(driver_id, cost_object_nm, value) VALUES(?, ?, ?)",
-                (d_id, co_name, value))
+                "INSERT INTO driver_values(driver_id, product, value) VALUES(?, ?, ?)",
+                (d_id, product, value))
             # No need to store dv_id unless we want mapping for something later
 
     # Import Resource Allocations
     for _, row in df_res_alloc.iterrows():
         # Use provided IDs if available; otherwise lookup by name
-        r_id = int(row["resource_id"]) if pd.notna(
-            row["resource_id"]) else None
-        a_id = int(row["activity_id"]) if pd.notna(
-            row["activity_id"]) else None
+        r_id = int(row["resource_id"]) if pd.notna(row["resource_id"]) else None
+        a_id = int(row["activity_id"]) if pd.notna(row["activity_id"]) else None
         r_name = str(row.get("resource_name", "")).strip()
-        a_name = str(row.get("activity_name", "")).strip()
+        act_bproc = str(row.get("business_procces", "")).strip()
+        act_name = str(row.get("activity", "")).strip()
         if not r_id and r_name:
             # find resource id by name
             r_id = None
@@ -569,12 +584,13 @@ def import_from_excel(file_path: str):
             res = cur.fetchone()
             if res:
                 r_id = res[0]
-        if not a_id and a_name:
-            a_id = activity_map.get(a_name)
+        if not a_id and act_bproc and act_name:
+            a_id = activity_map.get((act_bproc, act_name))
             if not a_id:
-                # find in DB in case not in map
                 cur.execute(
-                    "SELECT id FROM activities WHERE name=?", (a_name,))
+                    "SELECT id FROM activities WHERE business_procces=? AND activity=?",
+                    (act_bproc, act_name),
+                )
                 res = cur.fetchone()
                 if res:
                     a_id = res[0]
@@ -591,29 +607,33 @@ def import_from_excel(file_path: str):
 
     # Import Activity Allocations
     for _, row in df_act_alloc.iterrows():
-        a_id = int(row["activity_id"]) if pd.notna(
-            row["activity_id"]) else None
-        c_id = int(row["cost_object_id"]) if pd.notna(
-            row["cost_object_id"]) else None
-        a_name = str(row.get("activity_name", "")).strip()
-        c_name = str(row.get("cost_object_name", "")).strip()
+        a_id = int(row["activity_id"]) if pd.notna(row["activity_id"]) else None
+        c_id = int(row["cost_object_id"]) if pd.notna(row["cost_object_id"]) else None
+        a_bproc = str(row.get("business_procces", "")).strip()
+        a_name = str(row.get("activity", "")).strip()
+        c_product = str(row.get("product", "")).strip()
+        c_bproc = str(row.get("cost_object_bp", "")).strip()
         drv_desc = str(row.get("driver_value", "")).strip()
         driver_amt = float(row.get("driver_amt", row.get("quantity", 0))) if pd.notna(row.get("driver_amt", row.get("quantity"))) else None
 
         # Lookup activity and cost object by name if IDs are missing
-        if not a_id and a_name:
-            a_id = activity_map.get(a_name)
+        if not a_id and a_bproc and a_name:
+            a_id = activity_map.get((a_bproc, a_name))
             if not a_id:
                 cur.execute(
-                    "SELECT id FROM activities WHERE name=?", (a_name,))
+                    "SELECT id FROM activities WHERE business_procces=? AND activity=?",
+                    (a_bproc, a_name),
+                )
                 res = cur.fetchone()
                 if res:
                     a_id = res[0]
-        if not c_id and c_name:
-            c_id = costobj_map.get(c_name)
+        if not c_id and c_product and c_bproc:
+            c_id = costobj_map.get((c_product, c_bproc))
             if not c_id:
                 cur.execute(
-                    "SELECT id FROM cost_objects WHERE name=?", (c_name,))
+                    "SELECT id FROM cost_objects WHERE product=? AND business_procces=?",
+                    (c_product, c_bproc),
+                )
                 res = cur.fetchone()
                 if res:
                     c_id = res[0]
@@ -631,7 +651,7 @@ def import_from_excel(file_path: str):
             act_driver_id = act_info[0] if act_info else None
             act_evenly = act_info[1] if act_info else 0
             if act_driver_id:
-                cur.execute("SELECT id FROM driver_values WHERE driver_id=? AND cost_object_nm=?",
+                cur.execute("SELECT id FROM driver_values WHERE driver_id=? AND product=?",
                             (act_driver_id, drv_desc))
                 val = cur.fetchone()
                 if val:
@@ -639,7 +659,7 @@ def import_from_excel(file_path: str):
             if driver_value_id is None:
                 # Try find by name globally if unique
                 cur.execute(
-                    "SELECT id FROM driver_values WHERE cost_object_nm=?", (drv_desc,))
+                    "SELECT id FROM driver_values WHERE product=?", (drv_desc,))
                 vals = cur.fetchall()
                 if len(vals) == 1:
                     driver_value_id = vals[0][0]

--- a/tests/test_allocations.py
+++ b/tests/test_allocations.py
@@ -31,15 +31,15 @@ def test_allocation_cost_split():
     # create driver and cost objects
     cur.execute("INSERT INTO drivers(name) VALUES('drv')")
     driver_id = cur.lastrowid
-    cur.execute("INSERT INTO cost_objects(name) VALUES('o1')")
+    cur.execute("INSERT INTO cost_objects(product,business_procces) VALUES('p1','bp1')")
     co1 = cur.lastrowid
-    cur.execute("INSERT INTO cost_objects(name) VALUES('o2')")
+    cur.execute("INSERT INTO cost_objects(product,business_procces) VALUES('p2','bp1')")
     co2 = cur.lastrowid
-    cur.execute("INSERT INTO driver_values(driver_id,cost_object_nm,value) VALUES(?,?,?)", (driver_id,'o1',2))
-    cur.execute("INSERT INTO driver_values(driver_id,cost_object_nm,value) VALUES(?,?,?)", (driver_id,'o2',1))
+    cur.execute("INSERT INTO driver_values(driver_id,product,value) VALUES(?,?,?)", (driver_id,'p1',2))
+    cur.execute("INSERT INTO driver_values(driver_id,product,value) VALUES(?,?,?)", (driver_id,'p2',1))
     cur.execute("INSERT INTO resources(name,cost_total,unit) VALUES('res',100,'u')")
     res_id = cur.lastrowid
-    cur.execute("INSERT INTO activities(name,driver_id,evenly) VALUES('act',?,0)", (driver_id,))
+    cur.execute("INSERT INTO activities(business_procces,activity,driver_id,evenly) VALUES('bp1','act',?,0)", (driver_id,))
     act_id = cur.lastrowid
     cur.execute("INSERT INTO resource_allocations(resource_id,activity_id,amount) VALUES(?,?,1)", (res_id, act_id))
     con.commit()
@@ -73,9 +73,9 @@ def test_unallocated_cost_calculation():
     cur = con.cursor()
     cur.execute("INSERT INTO resources(name,cost_total,unit) VALUES('r1',200,'u')")
     r_id = cur.lastrowid
-    cur.execute("INSERT INTO activities(name,driver_id,evenly) VALUES('a1',NULL,0)")
+    cur.execute("INSERT INTO activities(business_procces,activity,driver_id,evenly) VALUES('bp','a1',NULL,0)")
     a1 = cur.lastrowid
-    cur.execute("INSERT INTO activities(name,driver_id,evenly) VALUES('a2',NULL,0)")
+    cur.execute("INSERT INTO activities(business_procces,activity,driver_id,evenly) VALUES('bp','a2',NULL,0)")
     a2 = cur.lastrowid
     con.commit()
     con.close()

--- a/ui/allocation_page.py
+++ b/ui/allocation_page.py
@@ -434,7 +434,7 @@ class AllocationPage(NSObject):
             con = database.get_connection()
             cur = con.cursor()
             cur.execute(
-                "SELECT id, cost_object_nm FROM driver_values WHERE driver_id=?", (driver_id,))
+                "SELECT id, product FROM driver_values WHERE driver_id=?", (driver_id,))
             vals = [f"{row[0]}: {row[1]}" for row in cur.fetchall()]
             con.close()
             self.driver_val_cb.removeAllItems()

--- a/ui/drivers_page.py
+++ b/ui/drivers_page.py
@@ -70,7 +70,7 @@ class DriversPage(NSObject):
         # Table of driver values
         table2_rect = NSMakeRect(0, 30, 1000, 250)
         self.value_table = NSTableView.alloc().initWithFrame_(table2_rect)
-        for col_id, width in [("id", 120), ("cost_object_nm", 300), ("value", 100)]:
+        for col_id, width in [("id", 120), ("product", 300), ("value", 100)]:
             col = NSTableColumn.alloc().initWithIdentifier_(col_id)
             col.setWidth_(width)
             col.headerCell().setStringValue_(col_id)
@@ -134,7 +134,7 @@ class DriversPage(NSObject):
         elif tableView == self.value_table:
             if col_id == "id":
                 return str(self.value_rows[rowIndex][0])
-            elif col_id == "cost_object_nm":
+            elif col_id == "product":
                 return self.value_rows[rowIndex][1]
             elif col_id == "value":
                 return str(self.value_rows[rowIndex][2])
@@ -166,7 +166,7 @@ class DriversPage(NSObject):
             con = database.get_connection()
             cur = con.cursor()
             cur.execute(
-                "SELECT id, cost_object_nm, value FROM driver_values WHERE driver_id=?", (d_id,))
+                "SELECT id, product, value FROM driver_values WHERE driver_id=?", (d_id,))
             self.value_rows = cur.fetchall()
             con.close()
             self.value_table.reloadData()
@@ -178,7 +178,7 @@ class DriversPage(NSObject):
             if row < 0 or row >= len(self.value_rows):
                 return
             selected = self.value_rows[row]
-            # selected = (id, cost_object_nm, value)
+            # selected = (id, product, value)
             self.desc_field.setStringValue_(selected[1])
             self.val_field.setStringValue_(str(selected[2]))
 
@@ -282,10 +282,10 @@ class DriversPage(NSObject):
             row = self.value_table.selectedRow()
             val_id = self.value_rows[row][0]
             cur.execute(
-                "UPDATE driver_values SET cost_object_nm=?, value=? WHERE id=?", (co_name, val, val_id))
+                "UPDATE driver_values SET product=?, value=? WHERE id=?", (co_name, val, val_id))
         else:
             # Insert new driver value for current driver
-            cur.execute("INSERT INTO driver_values(driver_id, cost_object_nm, value) VALUES(?, ?, ?)",
+            cur.execute("INSERT INTO driver_values(driver_id, product, value) VALUES(?, ?, ?)",
                         (self.current_driver_id, co_name, val))
             val_id = cur.lastrowid
         try:
@@ -306,7 +306,7 @@ class DriversPage(NSObject):
             con2 = database.get_connection()
             cur2 = con2.cursor()
             cur2.execute(
-                "SELECT id, cost_object_nm, value FROM driver_values WHERE driver_id=?", (self.current_driver_id,))
+                "SELECT id, product, value FROM driver_values WHERE driver_id=?", (self.current_driver_id,))
             self.value_rows = cur2.fetchall()
             con2.close()
             self.value_table.reloadData()
@@ -347,7 +347,7 @@ class DriversPage(NSObject):
             con2 = database.get_connection()
             cur2 = con2.cursor()
             cur2.execute(
-                "SELECT id, cost_object_nm, value FROM driver_values WHERE driver_id=?", (self.current_driver_id,))
+                "SELECT id, product, value FROM driver_values WHERE driver_id=?", (self.current_driver_id,))
             self.value_rows = cur2.fetchall()
             con2.close()
             self.value_table.reloadData()


### PR DESCRIPTION
## Summary
- update schema for `activities`, `cost_objects` and `driver_values`
- adjust allocation logic to match on `business_procces` and `product`
- update import/export pipelines
- rename driver value references in UI code
- adapt tests for new structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687766d9a3d4832a822dacafdaa7cd03