### PR TITLE
Fix startup crash by updating activity queries

### DIFF
--- a/ui/allocation_page.py
+++ b/ui/allocation_page.py
@@ -257,8 +257,15 @@ class AllocationPage(NSObject):
         # Find IDs by name
         cur.execute("SELECT id FROM resources WHERE name=?", (r_name,))
         r_id = (cur.fetchone() or (None,))[0]
-        cur.execute("SELECT id FROM activities WHERE name=?", (a_name,))
-        a_id = (cur.fetchone() or (None,))[0]
+        bproc, act = self.parse_activity_name(a_name)
+        if bproc and act:
+            cur.execute(
+                "SELECT id FROM activities WHERE business_procces=? AND activity=?",
+                (bproc, act),
+            )
+            a_id = (cur.fetchone() or (None,))[0]
+        else:
+            a_id = None
         if r_id and a_id:
             cur.execute(
                 "DELETE FROM resource_allocations WHERE resource_id=? AND activity_id=?", (r_id, a_id))
@@ -359,10 +366,24 @@ class AllocationPage(NSObject):
         a_name, c_name, _ = self.act_alloc_rows[sel]
         con = database.get_connection()
         cur = con.cursor()
-        cur.execute("SELECT id FROM activities WHERE name=?", (a_name,))
-        a_id = (cur.fetchone() or (None,))[0]
-        cur.execute("SELECT id FROM cost_objects WHERE name=?", (c_name,))
-        c_id = (cur.fetchone() or (None,))[0]
+        bproc, act = self.parse_activity_name(a_name)
+        if bproc and act:
+            cur.execute(
+                "SELECT id FROM activities WHERE business_procces=? AND activity=?",
+                (bproc, act),
+            )
+            a_id = (cur.fetchone() or (None,))[0]
+        else:
+            a_id = None
+        prod, cbp = self.parse_costobj_name(c_name)
+        if prod and cbp:
+            cur.execute(
+                "SELECT id FROM cost_objects WHERE product=? AND business_procces=?",
+                (prod, cbp),
+            )
+            c_id = (cur.fetchone() or (None,))[0]
+        else:
+            c_id = None
         if a_id and c_id:
             cur.execute(
                 "DELETE FROM activity_allocations WHERE activity_id=? AND cost_object_id=?", (a_id, c_id))
@@ -378,11 +399,15 @@ class AllocationPage(NSObject):
         cur = con.cursor()
         cur.execute("SELECT id, name FROM resources")
         res_list = [f"{r[0]}: {r[1]}" for r in cur.fetchall()]
-        cur.execute("SELECT id, name, driver_id, evenly FROM activities")
+        cur.execute(
+            "SELECT id, business_procces || ' X ' || activity AS name, driver_id, evenly FROM activities"
+        )
         acts = cur.fetchall()
         acts_list = [f"{a[0]}: {a[1]}" for a in acts]
         self.activities_info = {a[0]: (a[2], a[3]) for a in acts}
-        cur.execute("SELECT id, name FROM cost_objects")
+        cur.execute(
+            "SELECT id, product || ' X ' || business_procces AS name FROM cost_objects"
+        )
         objs_list = [f"{o[0]}: {o[1]}" for o in cur.fetchall()]
         con.close()
 
@@ -398,19 +423,23 @@ class AllocationPage(NSObject):
         # Refresh tables
         con2 = database.get_connection()
         cur2 = con2.cursor()
-        cur2.execute("""
-            SELECT r.name, a.name, ra.amount
-              FROM resource_allocations ra
-              JOIN resources  r ON r.id = ra.resource_id
-              JOIN activities a ON a.id = ra.activity_id
-        """)
+        cur2.execute(
+            """SELECT r.name,
+                      a.business_procces || ' X ' || a.activity AS act_name,
+                      ra.amount
+                 FROM resource_allocations ra
+                 JOIN resources  r ON r.id = ra.resource_id
+                 JOIN activities a ON a.id = ra.activity_id"""
+        )
         self.res_alloc_rows = cur2.fetchall()
-        cur2.execute("""
-            SELECT a.name, c.name, aa.driver_amt, aa.allocated_cost
-              FROM activity_allocations aa
-              JOIN activities   a ON a.id = aa.activity_id
-              JOIN cost_objects c ON c.id = aa.cost_object_id
-        """)
+        cur2.execute(
+            """SELECT a.business_procces || ' X ' || a.activity AS act_name,
+                      c.product || ' X ' || c.business_procces AS obj_name,
+                      aa.driver_amt, aa.allocated_cost
+                 FROM activity_allocations aa
+                 JOIN activities   a ON a.id = aa.activity_id
+                 JOIN cost_objects c ON c.id = aa.cost_object_id"""
+        )
         self.act_alloc_rows = cur2.fetchall()
         con2.close()
         self.tree_res_alloc.reloadData()
@@ -452,6 +481,18 @@ class AllocationPage(NSObject):
             return int(value.split(":")[0]) if value else None
         except Exception:
             return None
+
+    def parse_activity_name(self, text: str):
+        if "X" not in text:
+            return None, None
+        bproc, act = text.split("X", 1)
+        return bproc.strip(), act.strip()
+
+    def parse_costobj_name(self, text: str):
+        if "X" not in text:
+            return None, None
+        prod, bproc = text.split("X", 1)
+        return prod.strip(), bproc.strip()
 
     def __showError__(self, msg: str):
         alert = NSAlert.alloc().init()

--- a/ui/analysis_page.py
+++ b/ui/analysis_page.py
@@ -55,7 +55,9 @@ class AnalysisPage(NSObject):
     def refresh(self):
         con = database.get_connection()
         cur = con.cursor()
-        cur.execute("SELECT id, name FROM cost_objects")
+        cur.execute(
+            "SELECT id, product || ' X ' || business_procces AS name FROM cost_objects"
+        )
         self.objs = cur.fetchall()
         con.close()
         values = [f"{o[0]}: {o[1]}" for o in self.objs]
@@ -102,7 +104,10 @@ class AnalysisPage(NSObject):
     def get_activity_name(self, act_id):
         con = database.get_connection()
         cur = con.cursor()
-        cur.execute("SELECT name FROM activities WHERE id=?", (act_id,))
+        cur.execute(
+            "SELECT business_procces || ' X ' || activity FROM activities WHERE id=?",
+            (act_id,),
+        )
         row = cur.fetchone()
         con.close()
         return row[0] if row else str(act_id)

--- a/ui/graph_page.py
+++ b/ui/graph_page.py
@@ -96,9 +96,13 @@ class GraphPage(NSObject):
             con.close()
             return
         # Fetch names for activities and cost objects
-        cur.execute("SELECT id, name FROM activities")
+        cur.execute(
+            "SELECT id, business_procces || ' X ' || activity AS name FROM activities"
+        )
         all_activities = {row[0]: row[1] for row in cur.fetchall()}
-        cur.execute("SELECT id, name FROM cost_objects")
+        cur.execute(
+            "SELECT id, product || ' X ' || business_procces AS name FROM cost_objects"
+        )
         all_costobjs = {row[0]: row[1] for row in cur.fetchall()}
         con.close()
 

--- a/ui/visualization_page.py
+++ b/ui/visualization_page.py
@@ -62,7 +62,9 @@ class VisualizationPage(NSObject):
         costobj_totals = totals  # {cost_object_id: value}
         con2 = database.get_connection()
         cur2 = con2.cursor()
-        cur2.execute("SELECT id, name FROM cost_objects")
+        cur2.execute(
+            "SELECT id, product || ' X ' || business_procces AS name FROM cost_objects"
+        )
         all_costobjs = {row[0]: row[1] for row in cur2.fetchall()}
         con2.close()
         labels1 = []
@@ -77,7 +79,9 @@ class VisualizationPage(NSObject):
                 activity_totals[a_id] = activity_totals.get(a_id, 0) + value
         con3 = database.get_connection()
         cur3 = con3.cursor()
-        cur3.execute("SELECT id, name FROM activities")
+        cur3.execute(
+            "SELECT id, business_procces || ' X ' || activity AS name FROM activities"
+        )
         all_activities = {row[0]: row[1] for row in cur3.fetchall()}
         con3.close()
         labels2 = []


### PR DESCRIPTION
## Summary
- update ActivitiesPage queries for new schema
- update AllocationPage to split activity and cost object names
- adjust CostObjectsPage for product/business process fields
- fetch names using concatenated fields in GraphPage, VisualizationPage, and AnalysisPage
- add helper parsing functions for new name format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68776db85820832aa43307c51b6cdd60