### PR TITLE
Implement filtered graph view

### DIFF
--- a/graph_logic.py
+++ b/graph_logic.py
@@ -1,0 +1,107 @@
+import database
+
+
+def build_graph_data(product: str, bproc: str | None = None):
+    if not database.current_period:
+        return {}, {}, []
+    con = database.get_connection()
+    cur = con.cursor()
+    period = database.current_period
+    cur.execute(
+        "SELECT r.id, r.name, COALESCE(rc.cost, r.cost_total)"
+        " FROM resources r LEFT JOIN resource_costs rc"
+        " ON r.id = rc.resource_id AND rc.period=?",
+        (period,),
+    )
+    resource_data = {row[0]: {"name": row[1], "cost": row[2]} for row in cur.fetchall()}
+
+    cur.execute("SELECT resource_id, activity_id, amount FROM resource_allocations")
+    res_alloc = {}
+    total_by_res = {}
+    for r_id, a_id, amount in cur.fetchall():
+        res_alloc.setdefault(r_id, {})[a_id] = amount
+        total_by_res[r_id] = total_by_res.get(r_id, 0) + amount
+
+    activity_costs = {}
+    resource_to_activity = {}
+    for r_id, allocs in res_alloc.items():
+        total_amt = total_by_res.get(r_id, 0)
+        if total_amt == 0 or r_id not in resource_data:
+            continue
+        for a_id, amt in allocs.items():
+            share = amt / total_amt
+            cost_contrib = resource_data[r_id]["cost"] * share
+            activity_costs[a_id] = activity_costs.get(a_id, 0) + cost_contrib
+            resource_to_activity[(r_id, a_id)] = cost_contrib
+
+    cur.execute("SELECT activity_id, cost_object_id, driver_amt FROM activity_allocations")
+    act_alloc = {}
+    total_by_act = {}
+    for a_id, c_id, amt in cur.fetchall():
+        act_alloc.setdefault(a_id, {})[c_id] = amt
+        total_by_act[a_id] = total_by_act.get(a_id, 0) + amt
+
+    cost_object_totals = {}
+    activity_to_costobj = {}
+    for a_id, cost in activity_costs.items():
+        total_qty = total_by_act.get(a_id, 0)
+        if total_qty == 0:
+            continue
+        for c_id, qty in act_alloc.get(a_id, {}).items():
+            share = qty / total_qty
+            value = cost * share
+            cost_object_totals[c_id] = cost_object_totals.get(c_id, 0) + value
+            activity_to_costobj[(a_id, c_id)] = value
+
+    cur.execute("SELECT id, business_procces || ' X ' || activity AS name FROM activities")
+    all_activities = {row[0]: row[1] for row in cur.fetchall()}
+    cur.execute("SELECT id, product, business_procces FROM cost_objects")
+    cost_obj_rows = cur.fetchall()
+    con.close()
+
+    selected_cos = [row[0] for row in cost_obj_rows if row[1] == product and (bproc is None or row[2] == bproc)]
+    selected_cos = set(selected_cos)
+    if not selected_cos:
+        return {}, {}, []
+
+    node_labels = {}
+    node_colors = {}
+    edges = []
+
+    for (a_id, c_id), value in activity_to_costobj.items():
+        if c_id not in selected_cos:
+            continue
+        edges.append((f"A{a_id}", f"O{c_id}", value))
+
+    keep_activities = {int(e[0][1:]) for e in edges}
+
+    for (r_id, a_id), value in resource_to_activity.items():
+        if a_id in keep_activities:
+            edges.append((f"R{r_id}", f"A{a_id}", value))
+
+    keep_resources = {int(e[0][1:]) for e in edges if e[0].startswith("R")}
+
+    for r_id in keep_resources:
+        data = resource_data.get(r_id)
+        if data and data["cost"] is not None:
+            node_labels[f"R{r_id}"] = f"R: {data['name']}\n{data['cost']:.2f}"
+            node_colors[f"R{r_id}"] = "#FF6666"
+
+    for a_id in keep_activities:
+        name = all_activities.get(a_id, str(a_id))
+        cost = activity_costs.get(a_id, 0)
+        node_labels[f"A{a_id}"] = f"A: {name}\n{cost:.2f}"
+        node_colors[f"A{a_id}"] = "#FFCC33"
+
+    for c_id in selected_cos:
+        total = cost_object_totals.get(c_id, 0)
+        for row in cost_obj_rows:
+            if row[0] == c_id:
+                name = f"{row[1]} X {row[2]}"
+                break
+        else:
+            name = str(c_id)
+        node_labels[f"O{c_id}"] = f"O: {name}\n{total:.2f}"
+        node_colors[f"O{c_id}"] = "#99CC66"
+
+    return node_labels, node_colors, edges

--- a/tests/test_graph_page.py
+++ b/tests/test_graph_page.py
@@ -1,0 +1,63 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import database
+from graph_logic import build_graph_data
+
+DB = database.DB_NAME
+
+def setup_module(module):
+    if os.path.exists(DB):
+        os.remove(DB)
+    database.init_db()
+    database.reset_all_tables()
+    database.current_period = '2025-01'
+
+    con = database.get_connection()
+    cur = con.cursor()
+    # resources
+    cur.execute("INSERT INTO resources(name,cost_total,unit) VALUES('R1',100,'u')")
+    res = cur.lastrowid
+    # activities
+    cur.execute("INSERT INTO activities(business_procces,activity,driver_id,evenly) VALUES('bp1','a1',NULL,0)")
+    act1 = cur.lastrowid
+    cur.execute("INSERT INTO activities(business_procces,activity,driver_id,evenly) VALUES('bp2','a2',NULL,0)")
+    act2 = cur.lastrowid
+    # cost objects
+    cur.execute("INSERT INTO cost_objects(product,business_procces) VALUES('p1','b1')")
+    co1 = cur.lastrowid
+    cur.execute("INSERT INTO cost_objects(product,business_procces) VALUES('p1','b2')")
+    co2 = cur.lastrowid
+    cur.execute("INSERT INTO cost_objects(product,business_procces) VALUES('p2','b1')")
+    co3 = cur.lastrowid
+    # allocations
+    cur.execute("INSERT INTO resource_allocations(resource_id,activity_id,amount) VALUES(?,?,1)", (res, act1))
+    cur.execute("INSERT INTO resource_allocations(resource_id,activity_id,amount) VALUES(?,?,1)", (res, act2))
+    cur.execute("INSERT INTO activity_allocations(activity_id,cost_object_id,driver_amt) VALUES(?,?,1)", (act1, co1))
+    cur.execute("INSERT INTO activity_allocations(activity_id,cost_object_id,driver_amt) VALUES(?,?,1)", (act1, co2))
+    cur.execute("INSERT INTO activity_allocations(activity_id,cost_object_id,driver_amt) VALUES(?,?,1)", (act2, co3))
+    con.commit()
+    con.close()
+    database.update_activity_costs()
+
+
+def test_product_filter():
+    labels, _, edges = build_graph_data('p1')
+    nodes = set(labels.keys())
+    assert any(n.startswith('O') and 'p1' in labels[n] for n in nodes)
+    assert all(not labels[n].startswith('O: p2') for n in nodes)
+    edge_targets = {e[1] for e in edges if e[1].startswith('O')}
+    assert edge_targets == {'O1', 'O2'}
+
+
+def test_product_and_bproc_filter():
+    labels, _, edges = build_graph_data('p1', 'b2')
+    nodes = set(labels.keys())
+    # only cost object with b2
+    assert any('b2' in labels[n] for n in nodes if n.startswith('O'))
+    assert all('b2' in labels[n] for n in nodes if n.startswith('O'))
+    edge_targets = {e[1] for e in edges if e[1].startswith('O')}
+    assert edge_targets == {'O2'}
+    # only activity a1 connected
+    assert any(e[0] == 'A1' for e in edges)
+    assert all(e[0] != 'A2' for e in edges)

--- a/ui/graph_page.py
+++ b/ui/graph_page.py
@@ -2,12 +2,15 @@ from matplotlib.figure import Figure
 import io
 import objc
 from Cocoa import NSObject, NSMakeRect, NSData
-from AppKit import NSView, NSImageView, NSButton
-from AppKit import NSViewWidthSizable, NSViewHeightSizable
+from AppKit import (
+    NSView, NSImageView, NSButton, NSTextField, NSComboBox,
+    NSViewWidthSizable, NSViewHeightSizable, NSViewMinYMargin,
+)
 import database
 import matplotlib
 matplotlib.use("Agg")
 
+from graph_logic import build_graph_data
 
 class GraphPage(NSObject):
     def init(self):
@@ -16,133 +19,83 @@ class GraphPage(NSObject):
             return None
         content_rect = NSMakeRect(0, 0, 1000, 620)
         self.view = NSView.alloc().initWithFrame_(content_rect)
-        self.view.setAutoresizingMask_(
-            NSViewWidthSizable | NSViewHeightSizable)
+        self.view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
 
-        btn = NSButton.alloc().initWithFrame_(NSMakeRect(10, 580, 120, 30))
+        prod_label = NSTextField.labelWithString_("Product")
+        prod_label.setFrame_(NSMakeRect(5, 585, 70, 20))
+        self.view.addSubview_(prod_label)
+
+        self.product_cb = NSComboBox.alloc().initWithFrame_(NSMakeRect(80, 580, 150, 25))
+        self.product_cb.setEditable_(False)
+        self.product_cb.setTarget_(self)
+        self.product_cb.setAction_("productChanged:")
+        self.view.addSubview_(self.product_cb)
+
+        bp_label = NSTextField.labelWithString_("Business Process")
+        bp_label.setFrame_(NSMakeRect(235, 585, 120, 20))
+        self.view.addSubview_(bp_label)
+
+        self.bp_cb = NSComboBox.alloc().initWithFrame_(NSMakeRect(360, 580, 150, 25))
+        self.bp_cb.setEditable_(False)
+        self.view.addSubview_(self.bp_cb)
+
+        btn = NSButton.alloc().initWithFrame_(NSMakeRect(520, 578, 120, 30))
         btn.setTitle_("Show Graph")
         btn.setTarget_(self)
         btn.setAction_("showGraph:")
+        btn.setAutoresizingMask_(NSViewMinYMargin)
         self.view.addSubview_(btn)
 
-        # Draw initial graph (if any data)
-        self.refresh()
+        self.refresh_products()
         return self
 
-    def showGraph_(self, sender):
-        self.refresh()
+    def productChanged_(self, sender):
+        prod = sender.stringValue().strip()
+        con = database.get_connection()
+        cur = con.cursor()
+        if prod:
+            cur.execute(
+                "SELECT business_procces FROM cost_objects WHERE product=?",
+                (prod,),
+            )
+            vals = [row[0] for row in cur.fetchall()]
+        else:
+            vals = []
+        con.close()
+        self.bp_cb.removeAllItems()
+        if vals:
+            self.bp_cb.addItemsWithObjectValues_(vals)
 
-    def refresh(self):
-        # Remove previous graph image if exists
+    def refresh_products(self):
+        con = database.get_connection()
+        cur = con.cursor()
+        cur.execute("SELECT DISTINCT product FROM cost_objects")
+        prods = [row[0] for row in cur.fetchall()]
+        con.close()
+        self.product_cb.removeAllItems()
+        self.product_cb.addItemsWithObjectValues_(prods)
+        self.bp_cb.removeAllItems()
+
+    def showGraph_(self, sender):
+        product = self.product_cb.stringValue().strip()
+        if not product:
+            return
+        bproc = self.bp_cb.stringValue().strip()
+        if not bproc:
+            bproc = None
+        self.draw_graph(product, bproc)
+
+    def draw_graph(self, product: str, bproc: str | None = None):
         if hasattr(self, "img_view") and self.img_view:
             self.img_view.removeFromSuperview()
             self.img_view = None
-        # If no period selected, do nothing
-        if not database.current_period:
-            return
-        # Build model graph data for current period
-        con = database.get_connection()
-        cur = con.cursor()
-        period = database.current_period
-        # Resource costs
-        cur.execute("SELECT r.id, r.name, COALESCE(rc.cost, r.cost_total) FROM resources r LEFT JOIN resource_costs rc ON r.id = rc.resource_id AND rc.period=?", (period,))
-        resource_data = {row[0]: {"name": row[1], "cost": row[2]}
-                         for row in cur.fetchall()}
-        # Resource->Activity allocations
-        cur.execute(
-            "SELECT resource_id, activity_id, amount FROM resource_allocations"
-        )
-        res_alloc = {}
-        total_by_res = {}
-        for r_id, a_id, amount in cur.fetchall():
-            res_alloc.setdefault(r_id, {})[a_id] = amount
-            total_by_res[r_id] = total_by_res.get(r_id, 0) + amount
-        activity_costs = {}
-        resource_to_activity = {}
-        for r_id, allocs in res_alloc.items():
-            total_amt = total_by_res.get(r_id, 0)
-            if total_amt == 0 or r_id not in resource_data:
-                continue
-            for a_id, amt in allocs.items():
-                share = amt / total_amt
-                cost_contrib = resource_data[r_id]["cost"] * share
-                activity_costs[a_id] = activity_costs.get(
-                    a_id, 0) + cost_contrib
-                resource_to_activity[(r_id, a_id)] = cost_contrib
-        # Activity->CostObject allocations
-        cur.execute(
-            "SELECT activity_id, cost_object_id, driver_amt FROM activity_allocations"
-        )
-        act_alloc = {}
-        total_by_act = {}
-        for a_id, c_id, amt in cur.fetchall():
-            act_alloc.setdefault(a_id, {})[c_id] = amt
-            total_by_act[a_id] = total_by_act.get(a_id, 0) + amt
-        cost_object_totals = {}
-        activity_to_costobj = {}
-        for a_id, cost in activity_costs.items():
-            total_qty = total_by_act.get(a_id, 0)
-            if total_qty == 0:
-                # Activity has no allocations to cost objects (unallocated cost)
-                continue
-            for c_id, qty in act_alloc.get(a_id, {}).items():
-                share = qty / total_qty
-                value = cost * share
-                cost_object_totals[c_id] = cost_object_totals.get(
-                    c_id, 0) + value
-                activity_to_costobj[(a_id, c_id)] = value
-        # If no activities have cost, nothing to draw
-        if not activity_costs:
-            con.close()
-            return
-        # Fetch names for activities and cost objects
-        cur.execute(
-            "SELECT id, business_procces || ' X ' || activity AS name FROM activities"
-        )
-        all_activities = {row[0]: row[1] for row in cur.fetchall()}
-        cur.execute(
-            "SELECT id, product || ' X ' || business_procces AS name FROM cost_objects"
-        )
-        all_costobjs = {row[0]: row[1] for row in cur.fetchall()}
-        con.close()
-
-        # Build nodes and edges manually
-        node_labels = {}
-        node_colors = {}
-        edges = []
-
-        for r_id, data in resource_data.items():
-            if data["cost"] is None:
-                continue
-            node = f"R{r_id}"
-            node_labels[node] = f"R: {data['name']}\n{data['cost']:.2f}"
-            node_colors[node] = "#FF6666"
-
-        for a_id, cost in activity_costs.items():
-            node = f"A{a_id}"
-            name = all_activities.get(a_id, str(a_id))
-            node_labels[node] = f"A: {name}\n{cost:.2f}"
-            node_colors[node] = "#FFCC33"
-
-        for c_id, total in cost_object_totals.items():
-            node = f"O{c_id}"
-            name = all_costobjs.get(c_id, str(c_id))
-            node_labels[node] = f"O: {name}\n{total:.2f}"
-            node_colors[node] = "#99CC66"
-
-        for (r_id, a_id), value in resource_to_activity.items():
-            edges.append((f"R{r_id}", f"A{a_id}", value))
-
-        for (a_id, c_id), value in activity_to_costobj.items():
-            edges.append((f"A{a_id}", f"O{c_id}", value))
-
-        if not activity_costs:
-            con.close()
+        if not database.current_period or not product:
             return
 
-        con.close()
+        node_labels, node_colors, edges = build_graph_data(product, bproc)
+        if not node_labels:
+            return
 
-        # Layout positions
         pos = {}
         R_nodes = sorted([n for n in node_labels if n.startswith("R")], key=lambda x: int(x[1:]))
         A_nodes = sorted([n for n in node_labels if n.startswith("A")], key=lambda x: int(x[1:]))
@@ -172,23 +125,19 @@ class GraphPage(NSObject):
             ax.plot([x1, x2], [y1, y2], color="gray", zorder=1)
             ax.text((x1 + x2) / 2, (y1 + y2) / 2, f"{val:.2f}", fontsize=8, ha="center", va="center")
 
-        # Convert plot to NSImage for display in the UI
         buf = io.BytesIO()
         fig.savefig(buf, format="png")
         img_data = buf.getvalue()
         nsdata = NSData.dataWithBytes_length_(img_data, len(img_data))
-        image = objc.lookUpClass("NSImage").alloc(
-        ).initWithData_(nsdata) if nsdata else None
+        image = objc.lookUpClass("NSImage").alloc().initWithData_(nsdata) if nsdata else None
         if not image:
             return
-        self.img_view = NSImageView.alloc().initWithFrame_(
-            NSMakeRect(0, 0, self.view.frame().size.width, 620))
+        self.img_view = NSImageView.alloc().initWithFrame_(NSMakeRect(0, 0, self.view.frame().size.width, 620))
         self.img_view.setImage_(image)
         try:
             from AppKit import NSImageScaleProportionallyUpOrDown
             self.img_view.setImageScaling_(NSImageScaleProportionallyUpOrDown)
         except Exception:
             pass
-        self.img_view.setAutoresizingMask_(
-            NSViewWidthSizable | NSViewHeightSizable)
+        self.img_view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
         self.view.addSubview_(self.img_view)


### PR DESCRIPTION
## Summary
- add dropdowns on graph page for product and business process
- implement new `build_graph_data` logic in separate module
- update graph drawing to use selected filters
- add tests for graph filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b721512c832ab09e0d116853ba51