### PR TITLE
UI cleanup for dropdowns

### DIFF
--- a/database.py
+++ b/database.py
@@ -2,7 +2,8 @@ import sqlite3
 import pandas as pd
 
 DB_NAME = "abm_data.db"
-current_period = None  # Currently selected period (YYYY-MM)
+# Default to the first period; can be changed by the UI
+current_period = "2025-01"
 
 
 def get_connection():

--- a/ui/graph_page.py
+++ b/ui/graph_page.py
@@ -6,6 +6,7 @@ from AppKit import (
     NSView, NSImageView, NSButton, NSTextField, NSComboBox,
     NSViewWidthSizable, NSViewHeightSizable, NSViewMinYMargin,
 )
+from ui.allocation_page import COMBO_VISIBLE_ITEMS
 import database
 import matplotlib
 matplotlib.use("Agg")
@@ -17,29 +18,35 @@ class GraphPage(NSObject):
         self = objc.super(GraphPage, self).init()
         if self is None:
             return None
-        content_rect = NSMakeRect(0, 0, 1000, 620)
+        content_rect = NSMakeRect(0, 0, 1400, 620)
         self.view = NSView.alloc().initWithFrame_(content_rect)
         self.view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
 
         prod_label = NSTextField.labelWithString_("Product")
         prod_label.setFrame_(NSMakeRect(5, 585, 70, 20))
+        prod_label.setAutoresizingMask_(NSViewMinYMargin)
         self.view.addSubview_(prod_label)
 
-        self.product_cb = NSComboBox.alloc().initWithFrame_(NSMakeRect(80, 580, 150, 25))
+        self.product_cb = NSComboBox.alloc().initWithFrame_(NSMakeRect(80, 580, 450, 25))
         self.product_cb.setEditable_(False)
+        self.product_cb.setNumberOfVisibleItems_(COMBO_VISIBLE_ITEMS)
+        self.product_cb.setAutoresizingMask_(NSViewMinYMargin)
         self.product_cb.setTarget_(self)
         self.product_cb.setAction_("productChanged:")
         self.view.addSubview_(self.product_cb)
 
         bp_label = NSTextField.labelWithString_("Business Process")
-        bp_label.setFrame_(NSMakeRect(235, 585, 120, 20))
+        bp_label.setFrame_(NSMakeRect(540, 585, 120, 20))
+        bp_label.setAutoresizingMask_(NSViewMinYMargin)
         self.view.addSubview_(bp_label)
 
-        self.bp_cb = NSComboBox.alloc().initWithFrame_(NSMakeRect(360, 580, 150, 25))
+        self.bp_cb = NSComboBox.alloc().initWithFrame_(NSMakeRect(665, 580, 450, 25))
         self.bp_cb.setEditable_(False)
+        self.bp_cb.setNumberOfVisibleItems_(COMBO_VISIBLE_ITEMS)
+        self.bp_cb.setAutoresizingMask_(NSViewMinYMargin)
         self.view.addSubview_(self.bp_cb)
 
-        btn = NSButton.alloc().initWithFrame_(NSMakeRect(520, 578, 120, 30))
+        btn = NSButton.alloc().initWithFrame_(NSMakeRect(1125, 578, 120, 30))
         btn.setTitle_("Show Graph")
         btn.setTarget_(self)
         btn.setAction_("showGraph:")
@@ -132,7 +139,8 @@ class GraphPage(NSObject):
         image = objc.lookUpClass("NSImage").alloc().initWithData_(nsdata) if nsdata else None
         if not image:
             return
-        self.img_view = NSImageView.alloc().initWithFrame_(NSMakeRect(0, 0, self.view.frame().size.width, 620))
+        height = self.view.frame().size.height - 60
+        self.img_view = NSImageView.alloc().initWithFrame_(NSMakeRect(0, 0, self.view.frame().size.width, height))
         self.img_view.setImage_(image)
         try:
             from AppKit import NSImageScaleProportionallyUpOrDown

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -4,7 +4,6 @@ from AppKit import (
     NSWindowStyleMaskTitled, NSWindowStyleMaskClosable, NSWindowStyleMaskResizable,
     NSWindowStyleMaskMiniaturizable, NSBackingStoreBuffered,
     NSViewWidthSizable, NSViewHeightSizable,
-    NSViewMinYMargin, NSViewMaxXMargin,
     NSOpenPanel, NSSavePanel, NSAlert
 )
 from ui.resources_page import ResourcesPage
@@ -135,66 +134,14 @@ class MainWindow(NSObject):
         graph_item.setView_(self.graphPage.view)
         self.tab_view.addTabViewItem_(graph_item)
 
-        # ---------- Лейбл и комбобокс «Месяц» в левом-верхнем углу ----------
-        # Размеры контролов и отступы
-        label_w, label_h = 30, 17
-        combo_w, combo_h = 150, 25
-        padding_x, padding_top = 10, 5
-
-        # Вычисляем y-координаты относительно левого-верхнего угла окна
-        label_y = rect.size.height - label_h - padding_top
-        combo_y = rect.size.height - combo_h - padding_top
-
-        # Лейбл
-        period_label = objc.lookUpClass(
-            "NSTextField").labelWithString_(" ")
-        period_label.setFrame_(NSMakeRect(
-            padding_x, label_y, label_w, label_h))
-        period_label.setAutoresizingMask_(
-            NSViewMinYMargin | NSViewMaxXMargin)  # фиксируем левый/верх
-        content_view.addSubview_(period_label)
-
-        # Комбо-бокс
-        self.period_cb = objc.lookUpClass("NSComboBox").alloc().initWithFrame_(
-            NSMakeRect(padding_x + label_w + 8, combo_y, combo_w, combo_h)
-        )
-        self.period_cb.setEditable_(False)
-        self.period_cb.setAutoresizingMask_(
-            NSViewMinYMargin | NSViewMaxXMargin)
-        content_view.addSubview_(self.period_cb)
-
-        # ---------- Заполняем список месяцев ----------
-        months = [
-            "Январь", "Февраль", "Март", "Апрель", "Май", "Июнь",
-            "Июль", "Август", "Сентябрь", "Октябрь", "Ноябрь", "Декабрь"
-        ]
-        display_months = [f"{m} 2025" for m in months] + ["Январь 2026"]
-        from datetime import datetime
-
-        current_year = datetime.now().year
-        if current_year == 2025:
-            display_months = display_months[:-1]  # убираем Январь-2026
-
-        self.period_codes = [
-            f"2025-{str(i).zfill(2)}" for i in range(1, 13)] + ["2026-01"]
-        if current_year == 2025:
-            self.period_codes = self.period_codes[:-1]
-
-        self.period_cb.addItemsWithObjectValues_(display_months)
-
-        # Текущий месяц по умолчанию
-        current_code = f"{datetime.now().year}-{str(datetime.now().month).zfill(2)}"
-        index = self.period_codes.index(
-            current_code) if current_code in self.period_codes else 0
-        self.period_cb.selectItemAtIndex_(index)
-
-        # Сохраняем выбранный период в «database»
-        if 0 <= index < len(self.period_codes):
-            database.current_period = self.period_codes[index]
-
-        # Обработчик изменения периода
-        self.period_cb.setTarget_(self)
-        self.period_cb.setAction_("periodChanged:")
+        # ---------- Set default period ----------
+        con = database.get_connection()
+        cur = con.cursor()
+        cur.execute("SELECT period FROM periods ORDER BY period LIMIT 1")
+        row = cur.fetchone()
+        con.close()
+        if row:
+            database.current_period = row[0]
 
         # ---------- Делегаты ----------
         self.window.setDelegate_(self)
@@ -229,22 +176,6 @@ class MainWindow(NSObject):
         if page_obj and hasattr(page_obj, "refresh"):
             page_obj.refresh()
 
-    # ==================== Смена периода ====================
-    def periodChanged_(self, sender):
-        sel_index = self.period_cb.indexOfSelectedItem()
-        if sel_index < 0:
-            return
-        database.current_period = self.period_codes[sel_index]
-
-        # Обновляем страницы, зависящие от периода
-        for page in (
-            self.resourcesPage,
-            self.visualizationPage,
-            self.graphPage,
-            self.analysisPage,
-        ):
-            if hasattr(page, "refresh"):
-                page.refresh()
 
     # ==================== Import/Export ====================
     def importExcel_(self, sender):


### PR DESCRIPTION
## Summary
- remove month selection dropdown from main window
- anchor graph page dropdowns at top and match allocation page width
- ensure graph image respects dropdown area
- set default period on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878a85980cc832a8d5c3b3e60a43792