### PR TITLE
Add Sales page with import/export support

### DIFF
--- a/tests/test_sales_import_export.py
+++ b/tests/test_sales_import_export.py
@@ -1,0 +1,88 @@
+import os
+import pandas as pd
+import database
+
+DB = database.DB_NAME
+
+
+def setup_module(module):
+    if os.path.exists(DB):
+        os.remove(DB)
+    database.init_db()
+    database.reset_all_tables()
+
+
+def test_sales_roundtrip(tmp_path):
+    file_path = tmp_path / "model.xlsx"
+    df_resources = pd.DataFrame([{"id": 1, "name": "R", "cost_total": 10, "unit": "u"}])
+    df_activities = pd.DataFrame(
+        [
+            {
+                "id": 1,
+                "business_procces": "bp",
+                "activity": "a",
+                "driver": "",
+                "evenly": 0,
+            }
+        ]
+    )
+    df_costobj = pd.DataFrame([{"id": 1, "product": "p", "business_procces": "bp"}])
+    df_drivers = pd.DataFrame(columns=["id", "name"])
+    df_driver_vals = pd.DataFrame(columns=["id", "driver", "product", "value"])
+    df_res_alloc = pd.DataFrame([{"resource_id": 1, "activity_id": 1, "amount": 1}])
+    df_act_alloc = pd.DataFrame(
+        columns=[
+            "activity_id",
+            "cost_object_id",
+            "business_procces",
+            "activity",
+            "product",
+            "cost_object_bp",
+            "driver_value",
+            "driver_amt",
+        ]
+    )
+    df_sales = pd.DataFrame(
+        [
+            {
+                "id": 1,
+                "date": "2025-01-01",
+                "channel": "online",
+                "product": "p",
+                "cost_amt": 5,
+            },
+            {
+                "id": 2,
+                "date": "2025-01-02",
+                "channel": "retail",
+                "product": "p",
+                "cost_amt": 7,
+            },
+        ]
+    )
+    with pd.ExcelWriter(file_path, engine="openpyxl") as writer:
+        df_resources.to_excel(writer, sheet_name="Resources", index=False)
+        df_activities.to_excel(writer, sheet_name="Activities", index=False)
+        df_costobj.to_excel(writer, sheet_name="CostObjects", index=False)
+        df_drivers.to_excel(writer, sheet_name="Drivers", index=False)
+        df_driver_vals.to_excel(writer, sheet_name="DriverValues", index=False)
+        df_res_alloc.to_excel(writer, sheet_name="ResourceAllocations", index=False)
+        df_act_alloc.to_excel(writer, sheet_name="ActivityAllocations", index=False)
+        df_sales.to_excel(writer, sheet_name="Sales", index=False)
+
+    database.import_from_excel(str(file_path))
+    con = database.get_connection()
+    cur = con.cursor()
+    cur.execute("SELECT date, channel, product, cost_amt FROM sales ORDER BY id")
+    rows = cur.fetchall()
+    con.close()
+    assert rows == [
+        ("2025-01-01", "online", "p", 5.0),
+        ("2025-01-02", "retail", "p", 7.0),
+    ]
+
+    out_file = tmp_path / "export.xlsx"
+    database.export_to_excel(str(out_file))
+    df_out = pd.read_excel(out_file, "Sales")
+    assert len(df_out) == 2
+    assert list(df_out["channel"]) == ["online", "retail"]

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,10 +1,26 @@
 import objc
-from Cocoa import NSObject, NSApplication, NSApp, NSWindow, NSTabView, NSTabViewItem, NSMakeRect, NSMenu, NSMenuItem
+from Cocoa import (
+    NSObject,
+    NSApplication,
+    NSApp,
+    NSWindow,
+    NSTabView,
+    NSTabViewItem,
+    NSMakeRect,
+    NSMenu,
+    NSMenuItem,
+)
 from AppKit import (
-    NSWindowStyleMaskTitled, NSWindowStyleMaskClosable, NSWindowStyleMaskResizable,
-    NSWindowStyleMaskMiniaturizable, NSBackingStoreBuffered,
-    NSViewWidthSizable, NSViewHeightSizable,
-    NSOpenPanel, NSSavePanel, NSAlert
+    NSWindowStyleMaskTitled,
+    NSWindowStyleMaskClosable,
+    NSWindowStyleMaskResizable,
+    NSWindowStyleMaskMiniaturizable,
+    NSBackingStoreBuffered,
+    NSViewWidthSizable,
+    NSViewHeightSizable,
+    NSOpenPanel,
+    NSSavePanel,
+    NSAlert,
 )
 from ui.resources_page import ResourcesPage
 from ui.activities_page import ActivitiesPage
@@ -15,6 +31,7 @@ from ui.visualization_page import VisualizationPage
 from ui.drivers_page import DriversPage
 from ui.graph_page import GraphPage
 from ui.produced_amounts_window import ProducedAmountsWindow
+from ui.sales_page import SalesPage
 import database
 
 
@@ -28,9 +45,9 @@ class MainWindow(NSObject):
         app = NSApplication.sharedApplication()
         try:
             import AppKit
+
             if hasattr(AppKit, "NSApplicationActivationPolicyRegular"):
-                app.setActivationPolicy_(
-                    AppKit.NSApplicationActivationPolicyRegular)
+                app.setActivationPolicy_(AppKit.NSApplicationActivationPolicyRegular)
         except Exception:
             pass
 
@@ -53,7 +70,8 @@ class MainWindow(NSObject):
         main_menu.addItem_(app_item)
         app_menu = NSMenu.alloc().initWithTitle_("Application")
         quit_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-            "Quit", "terminate:", "q")
+            "Quit", "terminate:", "q"
+        )
         app_menu.addItem_(quit_item)
         app_item.setSubmenu_(app_menu)
 
@@ -61,11 +79,14 @@ class MainWindow(NSObject):
         main_menu.addItem_(file_item)
         file_menu = NSMenu.alloc().initWithTitle_("File")
         import_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-            "Import...", "importExcel:", "")
+            "Import...", "importExcel:", ""
+        )
         export_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-            "Export...", "exportExcel:", "")
+            "Export...", "exportExcel:", ""
+        )
         prod_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-            "Configure Produced Amounts", "openProdAmounts:", "")
+            "Configure Produced Amounts", "openProdAmounts:", ""
+        )
         file_menu.addItem_(import_item)
         file_menu.addItem_(export_item)
         file_menu.addItem_(prod_item)
@@ -75,14 +96,12 @@ class MainWindow(NSObject):
 
         # Контейнер для выпадающего списка и вкладок
         content_view = objc.lookUpClass("NSView").alloc().initWithFrame_(rect)
-        content_view.setAutoresizingMask_(
-            NSViewWidthSizable | NSViewHeightSizable)
+        content_view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
         self.window.setContentView_(content_view)
 
         # TabView на всё окно
         self.tab_view = NSTabView.alloc().initWithFrame_(rect)
-        self.tab_view.setAutoresizingMask_(
-            NSViewWidthSizable | NSViewHeightSizable)
+        self.tab_view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
         content_view.addSubview_(self.tab_view)
 
         # ---------- Страницы и вкладки ----------
@@ -109,6 +128,12 @@ class MainWindow(NSObject):
         costobj_item.setLabel_("Объекты затрат")
         costobj_item.setView_(self.costObjectsPage.view)
         self.tab_view.addTabViewItem_(costobj_item)
+
+        self.salesPage = SalesPage.alloc().init()
+        sales_item = NSTabViewItem.alloc().initWithIdentifier_("sales")
+        sales_item.setLabel_("Sales")
+        sales_item.setView_(self.salesPage.view)
+        self.tab_view.addTabViewItem_(sales_item)
 
         self.allocationPage = AllocationPage.alloc().init()
         allocation_item = NSTabViewItem.alloc().initWithIdentifier_("allocation")
@@ -156,6 +181,7 @@ class MainWindow(NSObject):
         app = NSApplication.sharedApplication()
         app.activateIgnoringOtherApps_(True)
         import PyObjCTools.AppHelper as AppHelper
+
         AppHelper.runEventLoop()
 
     def windowWillClose_(self, notification):
@@ -168,6 +194,7 @@ class MainWindow(NSObject):
             "activities": self.activitiesPage,
             "drivers": self.driversPage,
             "cost_objects": self.costObjectsPage,
+            "sales": self.salesPage,
             "allocation": self.allocationPage,
             "analysis": self.analysisPage,
             "visualization": self.visualizationPage,
@@ -176,12 +203,10 @@ class MainWindow(NSObject):
         if page_obj and hasattr(page_obj, "refresh"):
             page_obj.refresh()
 
-
     # ==================== Import/Export ====================
     def importExcel_(self, sender):
         panel = NSOpenPanel.openPanel()
-        panel.setAllowedFileTypes_(
-            ["xlsx"])
+        panel.setAllowedFileTypes_(["xlsx"])
         if panel.runModal():
             file_path = str(panel.URL().path())
             try:
@@ -219,6 +244,7 @@ class MainWindow(NSObject):
             self.activitiesPage,
             self.driversPage,
             self.costObjectsPage,
+            self.salesPage,
             self.allocationPage,
             self.analysisPage,
             self.visualizationPage,
@@ -226,4 +252,3 @@ class MainWindow(NSObject):
         ):
             if hasattr(page, "refresh"):
                 page.refresh()
-

--- a/ui/sales_page.py
+++ b/ui/sales_page.py
@@ -1,0 +1,171 @@
+import objc
+from Cocoa import NSObject, NSMakeRect
+from AppKit import (
+    NSView,
+    NSTextField,
+    NSButton,
+    NSScrollView,
+    NSTableView,
+    NSTableColumn,
+    NSAlert,
+    NSViewWidthSizable,
+    NSViewHeightSizable,
+    NSViewMaxYMargin,
+)
+import database
+
+
+class SalesPage(NSObject):
+    def init(self):
+        self = objc.super(SalesPage, self).init()
+        if self is None:
+            return None
+        content_rect = NSMakeRect(0, 0, 1000, 620)
+        self.view = NSView.alloc().initWithFrame_(content_rect)
+        self.view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
+        table_rect = NSMakeRect(0, 30, 1000, 590)
+        self.table = NSTableView.alloc().initWithFrame_(table_rect)
+        columns = [("date", 150), ("channel", 150), ("product", 150), ("cost_amt", 100)]
+        for col_id, width in columns:
+            col = NSTableColumn.alloc().initWithIdentifier_(col_id)
+            col.setWidth_(width)
+            col.headerCell().setStringValue_(col_id)
+            self.table.addTableColumn_(col)
+        self.table.setDelegate_(self)
+        self.table.setDataSource_(self)
+        self.table.setAllowsMultipleSelection_(False)
+        self.table.setUsesAlternatingRowBackgroundColors_(True)
+        scroll_view = NSScrollView.alloc().initWithFrame_(table_rect)
+        scroll_view.setDocumentView_(self.table)
+        scroll_view.setHasVerticalScroller_(True)
+        scroll_view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
+        self.view.addSubview_(scroll_view)
+        form_rect = NSMakeRect(0, 0, 1000, 30)
+        form_view = NSView.alloc().initWithFrame_(form_rect)
+        form_view.setAutoresizingMask_(NSViewWidthSizable | NSViewMaxYMargin)
+        date_label = NSTextField.labelWithString_("Date")
+        date_label.setFrame_(NSMakeRect(5, 5, 40, 20))
+        form_view.addSubview_(date_label)
+        self.date_field = NSTextField.alloc().initWithFrame_(NSMakeRect(50, 5, 100, 20))
+        form_view.addSubview_(self.date_field)
+        ch_label = NSTextField.labelWithString_("Channel")
+        ch_label.setFrame_(NSMakeRect(160, 5, 60, 20))
+        form_view.addSubview_(ch_label)
+        self.channel_field = NSTextField.alloc().initWithFrame_(
+            NSMakeRect(225, 5, 100, 20)
+        )
+        form_view.addSubview_(self.channel_field)
+        prod_label = NSTextField.labelWithString_("Product")
+        prod_label.setFrame_(NSMakeRect(335, 5, 60, 20))
+        form_view.addSubview_(prod_label)
+        self.product_field = NSTextField.alloc().initWithFrame_(
+            NSMakeRect(400, 5, 100, 20)
+        )
+        form_view.addSubview_(self.product_field)
+        cost_label = NSTextField.labelWithString_("Amount")
+        cost_label.setFrame_(NSMakeRect(510, 5, 50, 20))
+        form_view.addSubview_(cost_label)
+        self.cost_field = NSTextField.alloc().initWithFrame_(NSMakeRect(565, 5, 80, 20))
+        form_view.addSubview_(self.cost_field)
+        add_button = NSButton.alloc().initWithFrame_(NSMakeRect(655, 0, 100, 30))
+        add_button.setTitle_("Add / Update")
+        add_button.setTarget_(self)
+        add_button.setAction_("save:")
+        form_view.addSubview_(add_button)
+        del_button = NSButton.alloc().initWithFrame_(NSMakeRect(765, 0, 80, 30))
+        del_button.setTitle_("Delete")
+        del_button.setTarget_(self)
+        del_button.setAction_("delete:")
+        form_view.addSubview_(del_button)
+        self.view.addSubview_(form_view)
+        self.refresh()
+        return self
+
+    def numberOfRowsInTableView_(self, tableView):
+        return len(self.rows) if hasattr(self, "rows") else 0
+
+    def tableView_objectValueForTableColumn_row_(self, tableView, tableColumn, row):
+        col_id = str(tableColumn.identifier())
+        rec = self.rows[row]
+        if col_id == "date":
+            return rec[1]
+        elif col_id == "channel":
+            return rec[2]
+        elif col_id == "product":
+            return rec[3]
+        elif col_id == "cost_amt":
+            return str(rec[4])
+        return ""
+
+    def tableViewSelectionDidChange_(self, notification):
+        if self.table.numberOfSelectedRows() == 0:
+            return
+        row = self.table.selectedRow()
+        if row < 0 or row >= len(self.rows):
+            return
+        rec = self.rows[row]
+        self.date_field.setStringValue_(rec[1])
+        self.channel_field.setStringValue_(rec[2])
+        self.product_field.setStringValue_(rec[3])
+        self.cost_field.setStringValue_(str(rec[4]))
+
+    def save_(self, sender):
+        date = self.date_field.stringValue().strip()
+        channel = self.channel_field.stringValue().strip()
+        product = self.product_field.stringValue().strip()
+        cost_str = self.cost_field.stringValue().strip()
+        try:
+            cost = float(cost_str)
+        except ValueError:
+            alert = NSAlert.alloc().init()
+            alert.setMessageText_("Error")
+            alert.setInformativeText_("Invalid amount")
+            alert.runModal()
+            return
+        if not date or not channel or not product:
+            alert = NSAlert.alloc().init()
+            alert.setMessageText_("Error")
+            alert.setInformativeText_("All fields required")
+            alert.runModal()
+            return
+        con = database.get_connection()
+        cur = con.cursor()
+        if self.table.numberOfSelectedRows() > 0:
+            row = self.table.selectedRow()
+            sid = self.rows[row][0]
+            cur.execute(
+                "UPDATE sales SET date=?, channel=?, product=?, cost_amt=? WHERE id=?",
+                (date, channel, product, cost, sid),
+            )
+        else:
+            cur.execute(
+                "INSERT INTO sales(date, channel, product, cost_amt) VALUES(?, ?, ?, ?)",
+                (date, channel, product, cost),
+            )
+        con.commit()
+        con.close()
+        self.refresh()
+        self.clear_form()
+
+    def delete_(self, sender):
+        if self.table.numberOfSelectedRows() == 0:
+            return
+        row = self.table.selectedRow()
+        sid = self.rows[row][0]
+        con = database.get_connection()
+        con.execute("DELETE FROM sales WHERE id=?", (sid,))
+        con.commit()
+        con.close()
+        self.refresh()
+        self.clear_form()
+
+    def clear_form(self):
+        self.date_field.setStringValue_("")
+        self.channel_field.setStringValue_("")
+        self.product_field.setStringValue_("")
+        self.cost_field.setStringValue_("")
+        self.table.deselectAll_(None)
+
+    def refresh(self):
+        self.rows = database.get_sales()
+        self.table.reloadData()


### PR DESCRIPTION
## Summary
- create `sales` table and DB helper functions
- include sales data in Excel import/export
- add Cocoa UI page to manage sales data
- integrate Sales page into MainWindow
- test sales data roundtrip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a031f714832aa5312a7395a449a6