### PR TITLE
Fix PNL revenue vs cost

### DIFF
--- a/database.py
+++ b/database.py
@@ -190,6 +190,18 @@ def get_sales():
     return rows
 
 
+def get_revenue_and_cost(product: str) -> tuple[float, float]:
+    """Return total revenue and total cost for a product."""
+    con = get_connection()
+    cur = con.cursor()
+    cur.execute("SELECT SUM(cost_amt) FROM sales WHERE product=?", (product,))
+    revenue = cur.fetchone()[0] or 0.0
+    cur.execute("SELECT SUM(allocated_cost) FROM cost_objects WHERE product=?", (product,))
+    cost = cur.fetchone()[0] or 0.0
+    con.close()
+    return revenue, cost
+
+
 def update_even_allocations(activity_id: int, evenly: int) -> None:
     """Create or remove cost object allocations for an activity based on
     its evenly flag."""

--- a/tests/test_pnl.py
+++ b/tests/test_pnl.py
@@ -1,0 +1,46 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import database
+
+DB = database.DB_NAME
+
+
+def setup_module(module):
+    if os.path.exists(DB):
+        os.remove(DB)
+    database.init_db()
+    database.reset_all_tables()
+    database.current_period = '2025-01'
+
+    con = database.get_connection()
+    cur = con.cursor()
+    # resource and activity
+    cur.execute("INSERT INTO resources(name,cost_total,unit) VALUES('Res', 100, 'u')")
+    res = cur.lastrowid
+    cur.execute("INSERT INTO activities(business_procces,activity,driver_id,evenly) VALUES('bp','act',NULL,0)")
+    act = cur.lastrowid
+    # cost object
+    cur.execute("INSERT INTO cost_objects(product,business_procces) VALUES('p1','bp')")
+    co = cur.lastrowid
+    # allocations
+    cur.execute("INSERT INTO resource_allocations(resource_id,activity_id,amount) VALUES(?,?,1)", (res, act))
+    cur.execute("INSERT INTO activity_allocations(activity_id,cost_object_id,driver_amt) VALUES(?,?,1)", (act, co))
+    # sales
+    cur.execute("INSERT INTO sales(date, channel, product, cost_amt) VALUES('2025-01-01','online','p1',50)")
+    cur.execute("INSERT INTO sales(date, channel, product, cost_amt) VALUES('2025-01-02','retail','p1',70)")
+    con.commit()
+    con.close()
+    database.update_activity_costs()
+
+
+def test_revenue_and_cost_aggregation():
+    revenue, cost = database.get_revenue_and_cost('p1')
+    assert revenue == 120
+    # cost_objects should hold the allocated cost
+    con = database.get_connection()
+    cur = con.cursor()
+    cur.execute("SELECT allocated_cost FROM cost_objects WHERE product='p1'")
+    alloc = cur.fetchone()[0]
+    con.close()
+    assert cost == alloc

--- a/ui/pnl_page.py
+++ b/ui/pnl_page.py
@@ -101,12 +101,8 @@ class PNLPage(NSObject):
             (prod,),
         )
         rows = cur.fetchall()
-        cur.execute(
-            "SELECT SUM(allocated_cost) FROM cost_objects WHERE product=?", (prod,))
-        total_cost = cur.fetchone()[0] or 0
-        cur.execute("SELECT SUM(cost_amt) FROM sales WHERE product=?", (prod,))
-        total_rev = cur.fetchone()[0] or 0
         con.close()
+        total_rev, total_cost = database.get_revenue_and_cost(prod)
         labels = [r[0] for r in rows]
         values = [r[1] for r in rows]
         fig1 = Figure(figsize=(16, 3), dpi=100)


### PR DESCRIPTION
## Summary
- add a DB helper to return revenue and cost per product
- update PNL page to use this helper
- add unit test covering data used for PNL graph

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e2364c84832a84c02334dcf141f0