### PR TITLE
Add Yandex Market module scaffolding

### DIFF
--- a/services/yandex_market.py
+++ b/services/yandex_market.py
@@ -1,0 +1,174 @@
+import os
+import json
+from typing import Any, Dict, List, Tuple
+
+import requests
+
+ACCESS_TOKEN_PATH = "secrest/yandex_key.txt"
+
+
+class YandexMarketClient:
+    """Simple client for Yandex Market Partner API.
+
+    Only minimal functionality is implemented to satisfy the project requirements.
+    The client reads the access token from ``ACCESS_TOKEN_PATH`` and performs
+    basic requests to the Yandex Market API. If the token file is missing or
+    empty the methods will raise an exception.
+    """
+
+    def __init__(self, token_path: str = ACCESS_TOKEN_PATH):
+        self.token_path = token_path
+        self._token: str | None = None
+
+    # ------------------------------------------------------------------ utils
+    def _read_token(self) -> str:
+        if self._token is not None:
+            return self._token
+        if not os.path.exists(self.token_path):
+            raise FileNotFoundError(f"Token file not found: {self.token_path}")
+        with open(self.token_path, "r", encoding="utf-8") as f:
+            token = f.read().strip()
+        if not token:
+            raise ValueError("Token file is empty")
+        self._token = token
+        return token
+
+    def _headers(self) -> Dict[str, str]:
+        token = self._read_token()
+        return {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        }
+
+    # ------------------------------------------------------------------ public
+    def test_connection(self, config: Dict[str, Any]) -> Tuple[bool, str]:
+        """Try to perform a simple request to check that token and seller info
+        are valid.
+
+        Returns a tuple ``(success, message)``.
+        """
+
+        try:
+            headers = self._headers()
+        except Exception as exc:  # pragma: no cover - trivial
+            return False, str(exc)
+
+        # Yandex Market API has a ``ping`` endpoint. If it is not available we
+        # simply report that authentication looks OK.
+        url = "https://api.partner.market.yandex.ru/ping"
+        try:
+            resp = requests.get(url, headers=headers, timeout=5)
+            if resp.status_code == 200:
+                return True, "Connection successful"
+            return False, f"HTTP {resp.status_code}: {resp.text}"
+        except Exception as exc:  # pragma: no cover - network errors
+            return False, str(exc)
+
+    # ------------------------------------------------------------------
+    def fetch_sales(self, config: Dict[str, Any], date_from: str, date_to: str) -> List[Dict[str, Any]]:
+        """Fetch sales for the given date range.
+
+        The function parses a subset of the Yandex Market order representation
+        and returns a list of dictionaries with the following keys:
+        ``order_id``, ``order_date``, ``item_id``, ``item_name``, ``quantity``,
+        ``price``, ``currency``.
+
+        On any error an empty list is returned.
+        """
+
+        try:
+            headers = self._headers()
+        except Exception:
+            return []
+
+        campaign_id = config.get("campaign_id") or config.get("seller_id")
+        if not campaign_id:
+            return []
+
+        url = f"https://api.partner.market.yandex.ru/campaigns/{campaign_id}/orders.json"
+        params = {
+            "dateFrom": date_from,
+            "dateTo": date_to,
+        }
+        try:
+            resp = requests.get(url, headers=headers, params=params, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception:
+            return []
+
+        sales: List[Dict[str, Any]] = []
+        for order in data.get("orders", []):
+            order_id = order.get("id")
+            order_date = order.get("creationDate")
+            items = order.get("items") or []
+            for it in items:
+                sales.append(
+                    {
+                        "order_id": order_id,
+                        "order_date": order_date,
+                        "item_id": it.get("offerId"),
+                        "item_name": it.get("offerName"),
+                        "quantity": it.get("count", 1),
+                        "price": it.get("price", {}).get("amount", 0.0),
+                        "currency": it.get("price", {}).get("currency", "RUR"),
+                    }
+                )
+        return sales
+
+
+class ProductMappingStore:
+    """Persistent storage for mapping Yandex items to ABM products."""
+
+    def __init__(self, path: str = "yandex_product_mappings.json"):
+        self.path = path
+        self.mappings: Dict[str, str] = {}
+
+    # -------------------------------------------------------------- persistence
+    def load(self) -> Dict[str, str]:
+        if os.path.exists(self.path):
+            with open(self.path, "r", encoding="utf-8") as f:
+                self.mappings = json.load(f)
+        return self.mappings
+
+    def save(self) -> None:
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(self.mappings, f, ensure_ascii=False, indent=2)
+
+    def apply(self, raw_sales: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        result: List[Dict[str, Any]] = []
+        for rec in raw_sales:
+            pid = self.mappings.get(rec.get("item_id"))
+            res = dict(rec)
+            if pid:
+                res["product"] = pid
+            result.append(res)
+        return result
+
+
+class ABMImporter:
+    """Importer that writes normalized Yandex Market sales into the ABM DB."""
+
+    def __init__(self, db_module):
+        self.db = db_module
+
+    def upsert_sales(self, normalized_sales: List[Dict[str, Any]]) -> Dict[str, Any]:
+        con = self.db.get_connection()
+        cur = con.cursor()
+        inserted = 0
+        for rec in normalized_sales:
+            product = rec.get("product")
+            if not product:
+                continue
+            date = rec.get("order_date")
+            qty = rec.get("quantity", 0)
+            price = rec.get("price", 0)
+            amt = qty * price
+            cur.execute(
+                "INSERT INTO sales(date, channel, product, cost_amt) VALUES(?, ?, ?, ?)",
+                (date, "Yandex Market", product, amt),
+            )
+            inserted += 1
+        con.commit()
+        con.close()
+        return {"inserted": inserted}

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -31,6 +31,9 @@ from ui.drivers_page import DriversPage
 from ui.graph_page import GraphPage
 from ui.produced_amounts_window import ProducedAmountsWindow
 from ui.sales_page import SalesPage
+from ui.yandex_market_config_window import YandexMarketConfigWindow
+from ui.yandex_product_mapping_window import YandexProductMappingWindow
+from ui.yandex_market_sales_window import YandexMarketSalesWindow
 import database
 
 
@@ -90,6 +93,23 @@ class MainWindow(NSObject):
         file_menu.addItem_(export_item)
         file_menu.addItem_(prod_item)
         file_item.setSubmenu_(file_menu)
+
+        yandex_item = NSMenuItem.alloc().init()
+        main_menu.addItem_(yandex_item)
+        yandex_menu = NSMenu.alloc().initWithTitle_("Yandex Market Extension")
+        ym_conf = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            "Configure Yandex Market Extension", "openYandexConfig:", ""
+        )
+        ym_map = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            "Configure Yandex Market Product Names", "openYandexMapping:", ""
+        )
+        ym_sales = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            "Yandex Market Sales", "openYandexSales:", ""
+        )
+        yandex_menu.addItem_(ym_conf)
+        yandex_menu.addItem_(ym_map)
+        yandex_menu.addItem_(ym_sales)
+        yandex_item.setSubmenu_(yandex_menu)
 
         NSApp().setMainMenu_(main_menu)
 
@@ -229,6 +249,21 @@ class MainWindow(NSObject):
             self._prodAmtWin.refresh_callback = self.costObjectsPage.refresh
             self._prodAmtWin.on_close = lambda: setattr(self, "_prodAmtWin", None)
         self._prodAmtWin.show()
+
+    def openYandexConfig_(self, sender):
+        if not hasattr(self, "_ymConfWin") or self._ymConfWin is None:
+            self._ymConfWin = YandexMarketConfigWindow.alloc().init()
+        self._ymConfWin.show()
+
+    def openYandexMapping_(self, sender):
+        if not hasattr(self, "_ymMapWin") or self._ymMapWin is None:
+            self._ymMapWin = YandexProductMappingWindow.alloc().init()
+        self._ymMapWin.show()
+
+    def openYandexSales_(self, sender):
+        if not hasattr(self, "_ymSalesWin") or self._ymSalesWin is None:
+            self._ymSalesWin = YandexMarketSalesWindow.alloc().init()
+        self._ymSalesWin.show()
 
     def refresh_all_pages(self):
         for page in (

--- a/ui/yandex_market_config_window.py
+++ b/ui/yandex_market_config_window.py
@@ -1,0 +1,150 @@
+import json
+import os
+import objc
+from Cocoa import NSObject, NSMakeRect, NSWindow, NSAlert, NSOpenPanel, NSSavePanel, NSTextField, NSButton
+from AppKit import (
+    NSWindowStyleMaskTitled,
+    NSWindowStyleMaskClosable,
+    NSBackingStoreBuffered,
+    NSViewWidthSizable,
+    NSViewHeightSizable,
+    NSViewMaxYMargin,
+)
+
+from services.yandex_market import YandexMarketClient, ACCESS_TOKEN_PATH
+
+CONFIG_PATH = "yandex_market_config.json"
+
+
+class YandexMarketConfigWindow(NSObject):
+    def init(self):
+        self = objc.super(YandexMarketConfigWindow, self).init()
+        if self is None:
+            return None
+        rect = NSMakeRect(200, 200, 400, 240)
+        style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
+        self.window = NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
+            rect, style, NSBackingStoreBuffered, False
+        )
+        self.window.setTitle_("Configure Yandex Market Extension")
+        content = self.window.contentView()
+
+        token_label = NSTextField.labelWithString_(f"Token file: {ACCESS_TOKEN_PATH}")
+        token_label.setFrame_(NSMakeRect(10, 200, 380, 20))
+        content.addSubview_(token_label)
+
+        seller_label = NSTextField.labelWithString_("Seller ID")
+        seller_label.setFrame_(NSMakeRect(10, 170, 100, 20))
+        content.addSubview_(seller_label)
+        self.seller_field = NSTextField.alloc().initWithFrame_(NSMakeRect(120, 170, 150, 20))
+        content.addSubview_(self.seller_field)
+
+        camp_label = NSTextField.labelWithString_("Campaign ID")
+        camp_label.setFrame_(NSMakeRect(10, 140, 100, 20))
+        content.addSubview_(camp_label)
+        self.camp_field = NSTextField.alloc().initWithFrame_(NSMakeRect(120, 140, 150, 20))
+        content.addSubview_(self.camp_field)
+
+        from_label = NSTextField.labelWithString_("Default from")
+        from_label.setFrame_(NSMakeRect(10, 110, 100, 20))
+        content.addSubview_(from_label)
+        self.from_field = NSTextField.alloc().initWithFrame_(NSMakeRect(120, 110, 150, 20))
+        content.addSubview_(self.from_field)
+
+        to_label = NSTextField.labelWithString_("Default to")
+        to_label.setFrame_(NSMakeRect(10, 80, 100, 20))
+        content.addSubview_(to_label)
+        self.to_field = NSTextField.alloc().initWithFrame_(NSMakeRect(120, 80, 150, 20))
+        content.addSubview_(self.to_field)
+
+        save_btn = NSButton.alloc().initWithFrame_(NSMakeRect(10, 10, 80, 30))
+        save_btn.setTitle_("Save")
+        save_btn.setTarget_(self)
+        save_btn.setAction_("save:")
+        content.addSubview_(save_btn)
+
+        test_btn = NSButton.alloc().initWithFrame_(NSMakeRect(100, 10, 120, 30))
+        test_btn.setTitle_("Test connection")
+        test_btn.setTarget_(self)
+        test_btn.setAction_("test:")
+        content.addSubview_(test_btn)
+
+        export_btn = NSButton.alloc().initWithFrame_(NSMakeRect(230, 10, 70, 30))
+        export_btn.setTitle_("Export")
+        export_btn.setTarget_(self)
+        export_btn.setAction_("export:")
+        content.addSubview_(export_btn)
+
+        import_btn = NSButton.alloc().initWithFrame_(NSMakeRect(310, 10, 70, 30))
+        import_btn.setTitle_("Import")
+        import_btn.setTarget_(self)
+        import_btn.setAction_("import:")
+        content.addSubview_(import_btn)
+
+        self.load_config()
+        return self
+
+    # ------------------------------------------------------------------ helpers
+    def load_config(self):
+        if os.path.exists(CONFIG_PATH):
+            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+            self.seller_field.setStringValue_(cfg.get("seller_id", ""))
+            self.camp_field.setStringValue_(cfg.get("campaign_id", ""))
+            self.from_field.setStringValue_(cfg.get("date_from", ""))
+            self.to_field.setStringValue_(cfg.get("date_to", ""))
+
+    def current_config(self) -> dict:
+        return {
+            "seller_id": self.seller_field.stringValue(),
+            "campaign_id": self.camp_field.stringValue(),
+            "date_from": self.from_field.stringValue(),
+            "date_to": self.to_field.stringValue(),
+        }
+
+    def show(self):
+        self.window.makeKeyAndOrderFront_(None)
+
+    # ------------------------------------------------------------------ actions
+    def save_(self, sender):
+        cfg = self.current_config()
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, ensure_ascii=False, indent=2)
+
+    def test_(self, sender):
+        cfg = self.current_config()
+        client = YandexMarketClient()
+        success, message = client.test_connection(cfg)
+        alert = NSAlert.alloc().init()
+        if success:
+            alert.setMessageText_("Success")
+        else:
+            alert.setMessageText_("Error")
+        alert.setInformativeText_(message)
+        alert.runModal()
+
+    def export_(self, sender):
+        panel = NSSavePanel.savePanel()
+        if panel.runModal() == 0:
+            return
+        path = panel.URL().path()
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.current_config(), f, ensure_ascii=False, indent=2)
+
+    def import_(self, sender):
+        panel = NSOpenPanel.openPanel()
+        if panel.runModal() == 0:
+            return
+        path = panel.URLs()[0].path()
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+            self.seller_field.setStringValue_(cfg.get("seller_id", ""))
+            self.camp_field.setStringValue_(cfg.get("campaign_id", ""))
+            self.from_field.setStringValue_(cfg.get("date_from", ""))
+            self.to_field.setStringValue_(cfg.get("date_to", ""))
+        except Exception as exc:  # pragma: no cover - trivial UI
+            alert = NSAlert.alloc().init()
+            alert.setMessageText_("Error")
+            alert.setInformativeText_(str(exc))
+            alert.runModal()

--- a/ui/yandex_market_sales_window.py
+++ b/ui/yandex_market_sales_window.py
@@ -1,0 +1,209 @@
+import json
+import os
+import objc
+from Cocoa import NSObject, NSMakeRect, NSWindow, NSAlert, NSOpenPanel, NSSavePanel, NSTextField, NSButton, NSTableView, NSTableColumn, NSScrollView
+from AppKit import (
+    NSWindowStyleMaskTitled,
+    NSWindowStyleMaskClosable,
+    NSBackingStoreBuffered,
+    NSViewWidthSizable,
+    NSViewHeightSizable,
+    NSViewMaxYMargin,
+)
+
+from services.yandex_market import YandexMarketClient, ProductMappingStore, ABMImporter
+import database
+
+CONFIG_PATH = "yandex_market_config.json"
+CACHE_PATH = "yandex_sales_cache.json"
+
+
+class YandexMarketSalesWindow(NSObject):
+    def init(self):
+        self = objc.super(YandexMarketSalesWindow, self).init()
+        if self is None:
+            return None
+        rect = NSMakeRect(150, 150, 800, 500)
+        style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
+        self.window = NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
+            rect, style, NSBackingStoreBuffered, False
+        )
+        self.window.setTitle_("Yandex Market Sales")
+        content = self.window.contentView()
+
+        table_rect = NSMakeRect(0, 60, 800, 440)
+        self.table = NSTableView.alloc().initWithFrame_(table_rect)
+        cols = [
+            ("order_id", 100),
+            ("order_date", 120),
+            ("item_name", 200),
+            ("product", 150),
+            ("quantity", 70),
+            ("price", 80),
+        ]
+        for col_id, width in cols:
+            col = NSTableColumn.alloc().initWithIdentifier_(col_id)
+            col.setWidth_(width)
+            col.headerCell().setStringValue_(col_id)
+            self.table.addTableColumn_(col)
+        self.table.setDelegate_(self)
+        self.table.setDataSource_(self)
+        self.table.setAllowsMultipleSelection_(False)
+        self.table.setUsesAlternatingRowBackgroundColors_(True)
+        scroll = NSScrollView.alloc().initWithFrame_(table_rect)
+        scroll.setDocumentView_(self.table)
+        scroll.setHasVerticalScroller_(True)
+        scroll.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
+        content.addSubview_(scroll)
+
+        form_rect = NSMakeRect(0, 0, 800, 60)
+        form_view = objc.lookUpClass("NSView").alloc().initWithFrame_(form_rect)
+        form_view.setAutoresizingMask_(NSViewWidthSizable | NSViewMaxYMargin)
+        from_label = NSTextField.labelWithString_("From")
+        from_label.setFrame_(NSMakeRect(5, 30, 40, 20))
+        form_view.addSubview_(from_label)
+        self.from_field = NSTextField.alloc().initWithFrame_(NSMakeRect(50, 30, 100, 20))
+        form_view.addSubview_(self.from_field)
+        to_label = NSTextField.labelWithString_("To")
+        to_label.setFrame_(NSMakeRect(155, 30, 40, 20))
+        form_view.addSubview_(to_label)
+        self.to_field = NSTextField.alloc().initWithFrame_(NSMakeRect(190, 30, 100, 20))
+        form_view.addSubview_(self.to_field)
+
+        load_btn = NSButton.alloc().initWithFrame_(NSMakeRect(300, 25, 120, 30))
+        load_btn.setTitle_("Load data from API")
+        load_btn.setTarget_(self)
+        load_btn.setAction_("load:")
+        form_view.addSubview_(load_btn)
+
+        reapply_btn = NSButton.alloc().initWithFrame_(NSMakeRect(430, 25, 100, 30))
+        reapply_btn.setTitle_("Re-apply")
+        reapply_btn.setTarget_(self)
+        reapply_btn.setAction_("reapply:")
+        form_view.addSubview_(reapply_btn)
+
+        send_btn = NSButton.alloc().initWithFrame_(NSMakeRect(540, 25, 100, 30))
+        send_btn.setTitle_("Send to ABM")
+        send_btn.setTarget_(self)
+        send_btn.setAction_("send:")
+        form_view.addSubview_(send_btn)
+
+        export_btn = NSButton.alloc().initWithFrame_(NSMakeRect(650, 25, 70, 30))
+        export_btn.setTitle_("Export")
+        export_btn.setTarget_(self)
+        export_btn.setAction_("export:")
+        form_view.addSubview_(export_btn)
+
+        import_btn = NSButton.alloc().initWithFrame_(NSMakeRect(725, 25, 70, 30))
+        import_btn.setTitle_("Import")
+        import_btn.setTarget_(self)
+        import_btn.setAction_("import:")
+        form_view.addSubview_(import_btn)
+        content.addSubview_(form_view)
+
+        self.mapping_store = ProductMappingStore()
+        self.mapping_store.load()
+        self.raw_sales = []
+        self.sales = []
+        self.load_cache()
+        return self
+
+    def show(self):
+        self.window.makeKeyAndOrderFront_(None)
+
+    # ------------------------------------------------------------------ helpers
+    def load_cache(self):
+        if os.path.exists(CACHE_PATH):
+            with open(CACHE_PATH, "r", encoding="utf-8") as f:
+                self.raw_sales = json.load(f)
+            self.sales = self.mapping_store.apply(self.raw_sales)
+        else:
+            self.raw_sales = []
+            self.sales = []
+
+    def current_config(self):
+        if os.path.exists(CONFIG_PATH):
+            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+                return json.load(f)
+        return {}
+
+    # ------------------------------------------------------------------ table
+    def numberOfRowsInTableView_(self, tableView):
+        return len(self.sales)
+
+    def tableView_objectValueForTableColumn_row_(self, tableView, column, row):
+        col = str(column.identifier())
+        rec = self.sales[row]
+        if col == "order_id":
+            return rec.get("order_id")
+        if col == "order_date":
+            return rec.get("order_date")
+        if col == "item_name":
+            return rec.get("item_name")
+        if col == "product":
+            return rec.get("product", "")
+        if col == "quantity":
+            return str(rec.get("quantity", ""))
+        if col == "price":
+            return str(rec.get("price", ""))
+        return ""
+
+    # ------------------------------------------------------------------ actions
+    def load_(self, sender):
+        cfg = self.current_config()
+        date_from = self.from_field.stringValue() or cfg.get("date_from", "")
+        date_to = self.to_field.stringValue() or cfg.get("date_to", "")
+        client = YandexMarketClient()
+        try:
+            sales = client.fetch_sales(cfg, date_from, date_to)
+            self.raw_sales = sales
+            with open(CACHE_PATH, "w", encoding="utf-8") as f:
+                json.dump(self.raw_sales, f, ensure_ascii=False, indent=2)
+            self.sales = self.mapping_store.apply(self.raw_sales)
+            self.table.reloadData()
+        except Exception as exc:  # pragma: no cover
+            alert = NSAlert.alloc().init()
+            alert.setMessageText_("Error")
+            alert.setInformativeText_(str(exc))
+            alert.runModal()
+
+    def reapply_(self, sender):
+        self.sales = self.mapping_store.apply(self.raw_sales)
+        self.table.reloadData()
+
+    def send_(self, sender):
+        mapped = [s for s in self.sales if s.get("product")]
+        unmapped = len(self.sales) - len(mapped)
+        if unmapped:
+            alert = NSAlert.alloc().init()
+            alert.setMessageText_("Warning")
+            alert.setInformativeText_(
+                f"There are {unmapped} unmapped items. They will be skipped."
+            )
+            alert.runModal()
+        importer = ABMImporter(database)
+        report = importer.upsert_sales(mapped)
+        alert = NSAlert.alloc().init()
+        alert.setMessageText_("Done")
+        alert.setInformativeText_(f"Inserted {report['inserted']} records")
+        alert.runModal()
+
+    def export_(self, sender):
+        panel = NSSavePanel.savePanel()
+        if panel.runModal() == 0:
+            return
+        path = panel.URL().path()
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.raw_sales, f, ensure_ascii=False, indent=2)
+
+    def import_(self, sender):
+        panel = NSOpenPanel.openPanel()
+        if panel.runModal() == 0:
+            return
+        path = panel.URLs()[0].path()
+        with open(path, "r", encoding="utf-8") as f:
+            self.raw_sales = json.load(f)
+        with open(CACHE_PATH, "w", encoding="utf-8") as f:
+            json.dump(self.raw_sales, f, ensure_ascii=False, indent=2)
+        self.sales = self.mapping_store.apply(self.raw_sales)
+        self.table.reloadData()

--- a/ui/yandex_product_mapping_window.py
+++ b/ui/yandex_product_mapping_window.py
@@ -1,0 +1,156 @@
+import json
+import os
+import objc
+from Cocoa import NSObject, NSMakeRect, NSWindow, NSAlert, NSOpenPanel, NSSavePanel, NSTextField, NSButton, NSTableView, NSTableColumn, NSScrollView
+from AppKit import (
+    NSWindowStyleMaskTitled,
+    NSWindowStyleMaskClosable,
+    NSBackingStoreBuffered,
+    NSViewWidthSizable,
+    NSViewHeightSizable,
+    NSViewMaxYMargin,
+)
+
+from services.yandex_market import ProductMappingStore
+
+CACHE_PATH = "yandex_sales_cache.json"
+
+
+class YandexProductMappingWindow(NSObject):
+    def init(self):
+        self = objc.super(YandexProductMappingWindow, self).init()
+        if self is None:
+            return None
+        rect = NSMakeRect(150, 150, 600, 400)
+        style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
+        self.window = NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
+            rect, style, NSBackingStoreBuffered, False
+        )
+        self.window.setTitle_("Configure Yandex Market Product Names")
+        content = self.window.contentView()
+
+        table_rect = NSMakeRect(0, 40, 600, 360)
+        self.table = NSTableView.alloc().initWithFrame_(table_rect)
+        for col_id, width in [("item_id", 150), ("yandex_name", 250), ("product", 180)]:
+            col = NSTableColumn.alloc().initWithIdentifier_(col_id)
+            col.setWidth_(width)
+            col.headerCell().setStringValue_(col_id)
+            self.table.addTableColumn_(col)
+        self.table.setDelegate_(self)
+        self.table.setDataSource_(self)
+        self.table.setAllowsMultipleSelection_(False)
+        self.table.setUsesAlternatingRowBackgroundColors_(True)
+        scroll = NSScrollView.alloc().initWithFrame_(table_rect)
+        scroll.setDocumentView_(self.table)
+        scroll.setHasVerticalScroller_(True)
+        scroll.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
+        content.addSubview_(scroll)
+
+        form_rect = NSMakeRect(0, 0, 600, 40)
+        form_view = objc.lookUpClass("NSView").alloc().initWithFrame_(form_rect)
+        form_view.setAutoresizingMask_(NSViewWidthSizable | NSViewMaxYMargin)
+        prod_label = NSTextField.labelWithString_("Product")
+        prod_label.setFrame_(NSMakeRect(5, 10, 60, 20))
+        form_view.addSubview_(prod_label)
+        self.product_field = NSTextField.alloc().initWithFrame_(NSMakeRect(70, 10, 200, 20))
+        form_view.addSubview_(self.product_field)
+        assign_btn = NSButton.alloc().initWithFrame_(NSMakeRect(280, 5, 80, 30))
+        assign_btn.setTitle_("Assign")
+        assign_btn.setTarget_(self)
+        assign_btn.setAction_("assign:")
+        form_view.addSubview_(assign_btn)
+        save_btn = NSButton.alloc().initWithFrame_(NSMakeRect(370, 5, 60, 30))
+        save_btn.setTitle_("Save")
+        save_btn.setTarget_(self)
+        save_btn.setAction_("save:")
+        form_view.addSubview_(save_btn)
+        export_btn = NSButton.alloc().initWithFrame_(NSMakeRect(435, 5, 70, 30))
+        export_btn.setTitle_("Export")
+        export_btn.setTarget_(self)
+        export_btn.setAction_("export:")
+        form_view.addSubview_(export_btn)
+        import_btn = NSButton.alloc().initWithFrame_(NSMakeRect(510, 5, 70, 30))
+        import_btn.setTitle_("Import")
+        import_btn.setTarget_(self)
+        import_btn.setAction_("import:")
+        form_view.addSubview_(import_btn)
+        content.addSubview_(form_view)
+
+        self.store = ProductMappingStore()
+        self.store.load()
+        self.items = []
+        self.load_items()
+        return self
+
+    def show(self):
+        self.window.makeKeyAndOrderFront_(None)
+
+    # ------------------------------------------------------------------ table
+    def load_items(self):
+        if os.path.exists(CACHE_PATH):
+            with open(CACHE_PATH, "r", encoding="utf-8") as f:
+                sales = json.load(f)
+            seen = {}
+            for sale in sales:
+                iid = sale.get("item_id")
+                name = sale.get("item_name")
+                if iid:
+                    seen[iid] = name
+            self.items = [
+                (iid, name, self.store.mappings.get(iid)) for iid, name in seen.items()
+            ]
+        else:
+            self.items = []
+
+    def numberOfRowsInTableView_(self, tableView):
+        return len(self.items)
+
+    def tableView_objectValueForTableColumn_row_(self, tableView, column, row):
+        col = str(column.identifier())
+        item = self.items[row]
+        if col == "item_id":
+            return item[0]
+        if col == "yandex_name":
+            return item[1]
+        if col == "product":
+            return item[2] or ""
+        return ""
+
+    def tableViewSelectionDidChange_(self, notification):
+        if self.table.numberOfSelectedRows() == 0:
+            return
+        row = self.table.selectedRow()
+        self.product_field.setStringValue_(self.items[row][2] or "")
+
+    # ------------------------------------------------------------------ actions
+    def assign_(self, sender):
+        if self.table.numberOfSelectedRows() == 0:
+            return
+        row = self.table.selectedRow()
+        prod = self.product_field.stringValue().strip()
+        iid, name, _ = self.items[row]
+        self.store.mappings[iid] = prod
+        self.items[row] = (iid, name, prod)
+        self.table.reloadData()
+
+    def save_(self, sender):
+        self.store.save()
+
+    def export_(self, sender):
+        panel = NSSavePanel.savePanel()
+        if panel.runModal() == 0:
+            return
+        path = panel.URL().path()
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.store.mappings, f, ensure_ascii=False, indent=2)
+
+    def import_(self, sender):
+        panel = NSOpenPanel.openPanel()
+        if panel.runModal() == 0:
+            return
+        path = panel.URLs()[0].path()
+        with open(path, "r", encoding="utf-8") as f:
+            self.store.mappings = json.load(f)
+        self.store.save()
+        self.load_items()
+        self.table.reloadData()


### PR DESCRIPTION
## Summary
- integrate Yandex Market Extension menu with configuration, product mapping, and sales windows
- add Yandex Market service layer for API access, product mapping, and sales import

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899dd62d104832a8f87cdcf862b66b2